### PR TITLE
move PreviewMediaType => ReleasesMediaType

### DIFF
--- a/octokit/octokit.go
+++ b/octokit/octokit.go
@@ -10,7 +10,6 @@ const (
 	UserAgent          = "Octokat Go " + Version
 	MediaType          = "application/vnd.github.beta+json"
 	DefaultContentType = "application/json"
-	PreviewMediaType   = "application/vnd.github.manifold-preview"
 	Version            = "0.3.0"
 )
 

--- a/octokit/releases.go
+++ b/octokit/releases.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const ReleasesMediaType = "application/vnd.github.manifold-preview"
+
 type Release struct {
 	ID             int       `json:"id,omitempty"`
 	URL            string    `json:"url,omitempty"`
@@ -61,7 +63,7 @@ func addPreviewMediaType(options *Options) *Options {
 	}
 
 	if options.Headers["Accept"] == "" {
-		options.Headers["Accept"] = PreviewMediaType
+		options.Headers["Accept"] = ReleasesMediaType
 	}
 
 	return options

--- a/octokit/releases_test.go
+++ b/octokit/releases_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestAddPreviewMediaType(t *testing.T) {
 	options := addPreviewMediaType(nil)
-	assert.Equal(t, PreviewMediaType, options.Headers["Accept"])
+	assert.Equal(t, ReleasesMediaType, options.Headers["Accept"])
 }
 
 func TestReleases(t *testing.T) {
@@ -17,7 +17,7 @@ func TestReleases(t *testing.T) {
 
 	mux.HandleFunc("/repos/jingweno/gh/releases", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		testHeader(t, r, "Accept", PreviewMediaType)
+		testHeader(t, r, "Accept", ReleasesMediaType)
 		respondWith(w, loadFixture("releases.json"))
 	})
 
@@ -62,7 +62,7 @@ func TestCreateRelease(t *testing.T) {
 
 	mux.HandleFunc("/repos/octokit/Hello-World/releases", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		testHeader(t, r, "Accept", PreviewMediaType)
+		testHeader(t, r, "Accept", ReleasesMediaType)
 		testBody(t, r, `{"tag_name":"v1.0.0","target_commitish":"master"}`)
 		respondWith(w, loadFixture("create_release.json"))
 	})


### PR DESCRIPTION
Paves the way for future new endpoints with their own preview types.
