### PR TITLE
Add Accept header to HEAD and GET

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,6 +27,7 @@ func (c *Client) NewRequest(urlStr string) (req *Request, err error) {
 		return
 	}
 
+	sawyerReq.Header.Add("Accept", defaultMediaType)
 	sawyerReq.Header.Add("User-Agent", c.UserAgent)
 	sawyerReq.Header.Add("Authorization", c.AuthMethod.String())
 

--- a/client_test.go
+++ b/client_test.go
@@ -98,6 +98,7 @@ func TestSuccessfulPost(t *testing.T) {
 
 	mux.HandleFunc("/foo", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
+		testHeader(t, r, "Accept", defaultMediaType)
 		testHeader(t, r, "Content-Type", defaultMediaType)
 		testHeader(t, r, "User-Agent", userAgent)
 		testHeader(t, r, "Authorization", "token token")

--- a/request.go
+++ b/request.go
@@ -38,10 +38,8 @@ func (r *Request) do(method string, input interface{}, output interface{}) (resp
 	var sawyerResp *sawyer.Response
 	switch method {
 	case sawyer.HeadMethod:
-		r.sawyerReq.Header.Add("Accept", defaultMediaType)
 		sawyerResp = r.sawyerReq.Head()
 	case sawyer.GetMethod:
-		r.sawyerReq.Header.Add("Accept", defaultMediaType)
 		sawyerResp = r.sawyerReq.Get()
 	case sawyer.PostMethod:
 		mtype, _ := mediatype.Parse(defaultMediaType)


### PR DESCRIPTION
I need to confirm this, according to the [doc](http://developer.github.com/v3/media/), Accept header should be set. But [octokit.rb](https://github.com/octokit/octokit.rb/blob/9fece2bfed5d4f6448327d350315c8e699799a0b/lib/octokit/client.rb#L80-L81) only set it to HEAD and GET. Should I set it on all http verbs?

/cc @technoweenie @pengwynn
