### PR TITLE
Rename Get to One and GetAll to All

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ func main() {
       // Handle error
     }
 
-    user, result := client.Users(url).Get()
+    user, result := client.Users(url).One()
     if result.HasError() {
       // Handle error
     }
@@ -70,10 +70,10 @@ import "github.com/octokit/go-octokit/octokit"
 
 func main() {
   rootURL, _ := client.RootURL.Expand(nil)
-  root, _ := client.Root(rootURL).Get()
+  root, _ := client.Root(rootURL).One()
 
   userURL, _ := root.UserURL.Expand(octokit.M{"users": "jingweno"})
-  user, _ := client.Users(userURL).Get()
+  user, _ := client.Users(userURL).One()
 }
 ```
 
@@ -90,7 +90,7 @@ func main() {
       // Handle error
     }
 
-    users, result := client.Users(url).GetAll()
+    users, result := client.Users(url).All()
     if result.HasError() {
       // Handle error
     }
@@ -99,7 +99,7 @@ func main() {
 
     // Next page
     nextPageURL, _ := result.NextPage.Expand(nil)
-    users, result := client.Users(nextPageURL).GetAll()
+    users, result := client.Users(nextPageURL).All()
     if result.HasError() {
       // Handle error
     }

--- a/examples/example.go
+++ b/examples/example.go
@@ -21,7 +21,7 @@ func main() {
 			return
 		}
 
-		users, result := client.Users(url).GetAll()
+		users, result := client.Users(url).All()
 		if result.HasError() {
 			fmt.Println(result)
 			return

--- a/octokit/authorizations.go
+++ b/octokit/authorizations.go
@@ -21,12 +21,12 @@ type AuthorizationsService struct {
 	URL    *url.URL
 }
 
-func (a *AuthorizationsService) Get() (auth *Authorization, result *Result) {
+func (a *AuthorizationsService) One() (auth *Authorization, result *Result) {
 	result = a.client.get(a.URL, &auth)
 	return
 }
 
-func (a *AuthorizationsService) GetAll() (auths []Authorization, result *Result) {
+func (a *AuthorizationsService) All() (auths []Authorization, result *Result) {
 	result = a.client.get(a.URL, &auths)
 	return
 }

--- a/octokit/authorizations_test.go
+++ b/octokit/authorizations_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestAuthorizationsService_Get(t *testing.T) {
+func TestAuthorizationsService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
@@ -20,7 +20,7 @@ func TestAuthorizationsService_Get(t *testing.T) {
 	url, err := AuthorizationsURL.Expand(M{"id": 1})
 	assert.Equal(t, nil, err)
 
-	auth, result := client.Authorizations(url).Get()
+	auth, result := client.Authorizations(url).One()
 
 	assert.T(t, !result.HasError())
 	assert.Equal(t, 1, auth.ID)
@@ -39,7 +39,7 @@ func TestAuthorizationsService_Get(t *testing.T) {
 	assert.T(t, reflect.DeepEqual(auth.Scopes, scopes))
 }
 
-func TestAuthorizationsService_GetAll(t *testing.T) {
+func TestAuthorizationsService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
@@ -51,7 +51,7 @@ func TestAuthorizationsService_GetAll(t *testing.T) {
 	url, err := AuthorizationsURL.Expand(nil)
 	assert.Equal(t, nil, err)
 
-	auths, result := client.Authorizations(url).GetAll()
+	auths, result := client.Authorizations(url).All()
 	assert.T(t, !result.HasError())
 
 	firstAuth := auths[0]

--- a/octokit/issues.go
+++ b/octokit/issues.go
@@ -21,12 +21,12 @@ type IssuesService struct {
 	URL    *url.URL
 }
 
-func (i *IssuesService) Get() (issue *Issue, result *Result) {
+func (i *IssuesService) One() (issue *Issue, result *Result) {
 	result = i.client.get(i.URL, &issue)
 	return
 }
 
-func (i *IssuesService) GetAll() (issues []Issue, result *Result) {
+func (i *IssuesService) All() (issues []Issue, result *Result) {
 	result = i.client.get(i.URL, &issues)
 	return
 }

--- a/octokit/issues_test.go
+++ b/octokit/issues_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func TestIssuesService_GetAll(t *testing.T) {
+func TestIssuesService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
@@ -19,7 +19,7 @@ func TestIssuesService_GetAll(t *testing.T) {
 	url, err := RepoIssuesURL.Expand(M{"owner": "octocat", "repo": "Hello-World"})
 	assert.Equal(t, nil, err)
 
-	issues, result := client.Issues(url).GetAll()
+	issues, result := client.Issues(url).All()
 	assert.T(t, !result.HasError())
 	assert.Equal(t, 1, len(issues))
 
@@ -27,7 +27,7 @@ func TestIssuesService_GetAll(t *testing.T) {
 	validateIssue(t, issue)
 }
 
-func TestIssuesService_Get(t *testing.T) {
+func TestIssuesService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
@@ -39,7 +39,7 @@ func TestIssuesService_Get(t *testing.T) {
 	url, err := RepoIssuesURL.Expand(M{"owner": "octocat", "repo": "Hello-World", "number": 1347})
 	assert.Equal(t, nil, err)
 
-	issue, result := client.Issues(url).Get()
+	issue, result := client.Issues(url).One()
 
 	assert.T(t, !result.HasError())
 	validateIssue(t, *issue)

--- a/octokit/pull_requests.go
+++ b/octokit/pull_requests.go
@@ -21,7 +21,7 @@ type PullRequestsService struct {
 	URL    *url.URL
 }
 
-func (p *PullRequestsService) Get() (pull *PullRequest, result *Result) {
+func (p *PullRequestsService) One() (pull *PullRequest, result *Result) {
 	result = p.client.get(p.URL, &pull)
 	return
 }
@@ -31,7 +31,7 @@ func (p *PullRequestsService) Create(params interface{}) (pull *PullRequest, res
 	return
 }
 
-func (p *PullRequestsService) GetAll() (pulls []PullRequest, result *Result) {
+func (p *PullRequestsService) All() (pulls []PullRequest, result *Result) {
 	result = p.client.get(p.URL, &pulls)
 	return
 }

--- a/octokit/pull_requests_test.go
+++ b/octokit/pull_requests_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestPullRequestService_Get(t *testing.T) {
+func TestPullRequestService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
@@ -19,7 +19,7 @@ func TestPullRequestService_Get(t *testing.T) {
 	url, err := PullRequestsURL.Expand(M{"owner": "octokit", "repo": "go-octokit", "number": 1})
 	assert.Equal(t, nil, err)
 
-	pr, result := client.PullRequests(url).Get()
+	pr, result := client.PullRequests(url).One()
 
 	assert.T(t, !result.HasError())
 	assert.Equal(t, 1, pr.ChangedFiles)
@@ -95,7 +95,7 @@ func TestPullRequestService_Post(t *testing.T) {
 	assert.Equal(t, "https://api.github.com/repos/jingweno/octokat/issues/1/comments", pr.CommentsURL)
 }
 
-func TestPullRequestService_GetAll(t *testing.T) {
+func TestPullRequestService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
@@ -110,7 +110,7 @@ func TestPullRequestService_GetAll(t *testing.T) {
 	url, err := PullRequestsURL.Expand(M{"owner": "rails", "repo": "rails"})
 	assert.Equal(t, nil, err)
 
-	prs, result := client.PullRequests(url).GetAll()
+	prs, result := client.PullRequests(url).All()
 	assert.T(t, !result.HasError())
 	assert.Equal(t, 30, len(prs))
 	assert.Equal(t, testURLStringOf("repositories/8514/pulls?page=2"), string(*result.NextPage))

--- a/octokit/releases.go
+++ b/octokit/releases.go
@@ -53,7 +53,7 @@ type ReleasesService struct {
 	URL    *url.URL
 }
 
-func (r *ReleasesService) GetAll() (releases []Release, result *Result) {
+func (r *ReleasesService) All() (releases []Release, result *Result) {
 	result = r.client.get(r.URL, &releases)
 	return
 }

--- a/octokit/releases_test.go
+++ b/octokit/releases_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestReleasesService_GetAll(t *testing.T) {
+func TestReleasesService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
@@ -18,7 +18,7 @@ func TestReleasesService_GetAll(t *testing.T) {
 	url, err := ReleasesURL.Expand(M{"owner": "jingweno", "repo": "gh"})
 	assert.Equal(t, nil, err)
 
-	releases, result := client.Releases(url).GetAll()
+	releases, result := client.Releases(url).All()
 	assert.T(t, !result.HasError())
 	assert.Equal(t, 1, len(releases))
 

--- a/octokit/repositories.go
+++ b/octokit/repositories.go
@@ -24,12 +24,12 @@ type RepositoriesService struct {
 	URL    *url.URL
 }
 
-func (r *RepositoriesService) Get() (repo *Repository, result *Result) {
+func (r *RepositoriesService) One() (repo *Repository, result *Result) {
 	result = r.client.get(r.URL, &repo)
 	return
 }
 
-func (r *RepositoriesService) GetAll() (repos []Repository, result *Result) {
+func (r *RepositoriesService) All() (repos []Repository, result *Result) {
 	result = r.client.get(r.URL, &repos)
 	return
 }

--- a/octokit/repositories_test.go
+++ b/octokit/repositories_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestRepositoresService_Get(t *testing.T) {
+func TestRepositoresService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
@@ -20,7 +20,7 @@ func TestRepositoresService_Get(t *testing.T) {
 	url, err := RepositoryURL.Expand(M{"owner": "jingweno", "repo": "octokat"})
 	assert.Equal(t, nil, err)
 
-	repo, result := client.Repositories(url).Get()
+	repo, result := client.Repositories(url).One()
 
 	assert.T(t, !result.HasError())
 	assert.Equal(t, 10575811, repo.ID)
@@ -36,7 +36,7 @@ func TestRepositoresService_Get(t *testing.T) {
 	assert.Equal(t, "master", repo.MasterBranch)
 }
 
-func TestRepositoresService_GetAll(t *testing.T) {
+func TestRepositoresService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
@@ -53,7 +53,7 @@ func TestRepositoresService_GetAll(t *testing.T) {
 	url, err := OrgRepositoriesURL.Expand(M{"org": "rails"})
 	assert.Equal(t, nil, err)
 
-	repos, result := client.Repositories(url).GetAll()
+	repos, result := client.Repositories(url).All()
 
 	assert.T(t, !result.HasError())
 	assert.Equal(t, 30, len(repos))

--- a/octokit/root.go
+++ b/octokit/root.go
@@ -20,7 +20,7 @@ type RootService struct {
 	URL    *url.URL
 }
 
-func (r *RootService) Get() (root *Root, result *Result) {
+func (r *RootService) One() (root *Root, result *Result) {
 	result = r.client.get(r.URL, &root)
 	if root != nil {
 		// Cached hyperlinks

--- a/octokit/root_test.go
+++ b/octokit/root_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestRootService_Get(t *testing.T) {
+func TestRootService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
@@ -18,7 +18,7 @@ func TestRootService_Get(t *testing.T) {
 	url, err := RootURL.Expand(nil)
 	assert.Equal(t, nil, err)
 
-	root, result := client.Root(url).Get()
+	root, result := client.Root(url).One()
 	assert.T(t, !result.HasError())
 	assert.Equal(t, "https://api.github.com/users/{user}", string(root.UserURL))
 }

--- a/octokit/statuses.go
+++ b/octokit/statuses.go
@@ -21,7 +21,7 @@ type StatusesService struct {
 	URL    *url.URL
 }
 
-func (s *StatusesService) GetAll() (statuses []Status, result *Result) {
+func (s *StatusesService) All() (statuses []Status, result *Result) {
 	result = s.client.get(s.URL, &statuses)
 	return
 }

--- a/octokit/statuses_test.go
+++ b/octokit/statuses_test.go
@@ -19,7 +19,7 @@ func TestStatuses(t *testing.T) {
 	url, err := StatusesURL.Expand(M{"owner": "jingweno", "repo": "gh", "ref": sha})
 	assert.Equal(t, nil, err)
 
-	statuses, err := client.Statuses(url).GetAll()
+	statuses, err := client.Statuses(url).All()
 
 	assert.Equal(t, 2, len(statuses))
 	firstStatus := statuses[0]

--- a/octokit/users.go
+++ b/octokit/users.go
@@ -25,7 +25,7 @@ type UsersService struct {
 }
 
 // Get a user based on UserService#URL
-func (u *UsersService) Get() (user *User, result *Result) {
+func (u *UsersService) One() (user *User, result *Result) {
 	result = u.client.get(u.URL, &user)
 	return
 }
@@ -37,7 +37,7 @@ func (u *UsersService) Update(params interface{}) (user *User, result *Result) {
 }
 
 // Get a list of users based on UserService#URL
-func (u *UsersService) GetAll() (users []User, result *Result) {
+func (u *UsersService) All() (users []User, result *Result) {
 	result = u.client.get(u.URL, &users)
 	return
 }

--- a/octokit/users_test.go
+++ b/octokit/users_test.go
@@ -18,7 +18,7 @@ func TestUsersService_GetCurrentUser(t *testing.T) {
 	})
 
 	url, _ := CurrentUserURL.Expand(nil)
-	user, result := client.Users(url).Get()
+	user, result := client.Users(url).One()
 
 	assert.T(t, !result.HasError())
 	assert.Equal(t, 169064, user.ID)
@@ -61,7 +61,7 @@ func TestUsersService_GetUser(t *testing.T) {
 
 	url, err := UserURL.Expand(M{"user": "jingweno"})
 	assert.Equal(t, nil, err)
-	user, result := client.Users(url).Get()
+	user, result := client.Users(url).One()
 
 	assert.T(t, !result.HasError())
 	assert.Equal(t, 169064, user.ID)
@@ -71,7 +71,7 @@ func TestUsersService_GetUser(t *testing.T) {
 	assert.Equal(t, "https://api.github.com/users/jingweno/repos", string(user.ReposURL))
 }
 
-func TestUsersService_GetAll(t *testing.T) {
+func TestUsersService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
@@ -90,7 +90,7 @@ func TestUsersService_GetAll(t *testing.T) {
 	url, err := UserURL.Expand(M{"since": 1})
 	assert.Equal(t, nil, err)
 
-	allUsers, result := client.Users(url).GetAll()
+	allUsers, result := client.Users(url).All()
 
 	assert.T(t, !result.HasError())
 	assert.Equal(t, 1, len(allUsers))
@@ -99,7 +99,7 @@ func TestUsersService_GetAll(t *testing.T) {
 	nextPageURL, err := result.NextPage.Expand(nil)
 	assert.Equal(t, nil, err)
 
-	allUsers, result = client.Users(nextPageURL).GetAll()
+	allUsers, result = client.Users(nextPageURL).All()
 	assert.T(t, !result.HasError())
 	assert.Equal(t, 1, len(allUsers))
 }


### PR DESCRIPTION
Some syntactic sugars
