### PR TITLE
add client.Rels()

### DIFF
--- a/octokit/client.go
+++ b/octokit/client.go
@@ -2,6 +2,7 @@ package octokit
 
 import (
 	"github.com/lostisland/go-sawyer"
+	"github.com/lostisland/go-sawyer/hypermedia"
 	"net/http"
 	"net/url"
 )
@@ -19,6 +20,7 @@ type Client struct {
 	UserAgent    string
 	AuthMethod   AuthMethod
 	sawyerClient *sawyer.Client
+	rootRels     hypermedia.Relations
 }
 
 func (c *Client) NewRequest(urlStr string) (req *Request, err error) {

--- a/octokit/root.go
+++ b/octokit/root.go
@@ -9,6 +9,19 @@ var (
 	RootURL = Hyperlink("/")
 )
 
+func (c *Client) Rel(name string, m map[string]interface{}) (*url.URL, error) {
+	if c.rootRels == nil || len(c.rootRels) == 0 {
+		u, _ := url.Parse("/")
+		root, res := c.Root(u).One()
+		if res.HasError() {
+			return nil, res
+		}
+		c.rootRels = root.Rels()
+	}
+
+	return c.rootRels.Rel(name, m)
+}
+
 // Create a RooService with the base url.URL
 func (c *Client) Root(url *url.URL) (root *RootService) {
 	root = &RootService{client: c, URL: url}
@@ -21,10 +34,11 @@ type RootService struct {
 }
 
 func (r *RootService) One() (root *Root, result *Result) {
+	root = &Root{HALResource: &hypermedia.HALResource{}}
 	result = r.client.get(r.URL, &root)
 	if root != nil {
 		// Cached hyperlinks
-		root.PullsURL = PullRequestsURL
+		root.PullsURL = hypermedia.Hyperlink(PullRequestsURL)
 	}
 
 	return
@@ -33,32 +47,43 @@ func (r *RootService) One() (root *Root, result *Result) {
 type Root struct {
 	*hypermedia.HALResource
 
-	UserSearchURL               Hyperlink `json:"user_search_url,omitempty"`
-	UserRepositoriesURL         Hyperlink `json:"user_repositories_url,omitempty"`
-	UserOrganizationsURL        Hyperlink `json:"user_organizations_url,omitempty"`
-	UserURL                     Hyperlink `json:"user_url,omitempty"`
-	TeamURL                     Hyperlink `json:"team_url,omitempty"`
-	StarredGistsURL             Hyperlink `json:"starred_gists_url,omitempty"`
-	StarredURL                  Hyperlink `json:"starred_url,omitempty"`
-	CurrentUserRepositoriesURL  Hyperlink `json:"current_user_repositories_url,omitempty"`
-	RepositorySearchURL         Hyperlink `json:"repository_search_url,omitempty"`
-	RepositoryURL               Hyperlink `json:"repository_url,omitempty"`
-	RateLimitURL                Hyperlink `json:"rate_limit_url,omitempty"`
-	GistsURL                    Hyperlink `json:"gists_url,omitempty"`
-	FollowingURL                Hyperlink `json:"following_url,omitempty"`
-	FeedsURL                    Hyperlink `json:"feeds_url,omitempty"`
-	EventsURL                   Hyperlink `json:"events_url,omitempty"`
-	EmojisURL                   Hyperlink `json:"emojis_url,omitempty"`
-	EmailsURL                   Hyperlink `json:"emails_url,omitempty"`
-	AuthorizationsURL           Hyperlink `json:"authorizations_url,omitempty"`
-	CurrentUserURL              Hyperlink `json:"current_user_url,omitempty"`
-	HubURL                      Hyperlink `json:"hub_url,omitempty"`
-	IssueSearchURL              Hyperlink `json:"issue_search_url,omitempty"`
-	IssuesURL                   Hyperlink `json:"issues_url,omitempty"`
-	KeysURL                     Hyperlink `json:"keys_url,omitempty"`
-	NotificationsURL            Hyperlink `json:"notifications_url,omitempty"`
-	OrganizationRepositoriesURL Hyperlink `json:"organization_repositories_url,omitempty"`
-	OrganizationURL             Hyperlink `json:"organization_url,omitempty"`
-	PublicGistsURL              Hyperlink `json:"public_gists_url,omitempty"`
-	PullsURL                    Hyperlink `json:"-"`
+	UserSearchURL               hypermedia.Hyperlink `rel:"user_search" json:"user_search_url,omitempty"`
+	UserRepositoriesURL         hypermedia.Hyperlink `rel:"user_repositories" json:"user_repositories_url,omitempty"`
+	UserOrganizationsURL        hypermedia.Hyperlink `rel:"user_organizations" json:"user_organizations_url,omitempty"`
+	UserURL                     hypermedia.Hyperlink `rel:"user" json:"user_url,omitempty"`
+	TeamURL                     hypermedia.Hyperlink `rel:"team" json:"team_url,omitempty"`
+	StarredGistsURL             hypermedia.Hyperlink `rel:"starred_gists" json:"starred_gists_url,omitempty"`
+	StarredURL                  hypermedia.Hyperlink `rel:"starred" json:"starred_url,omitempty"`
+	CurrentUserRepositoriesURL  hypermedia.Hyperlink `rel:"current_user_repositories" json:"current_user_repositories_url,omitempty"`
+	RepositorySearchURL         hypermedia.Hyperlink `rel:"repository_search" json:"repository_search_url,omitempty"`
+	RepositoryURL               hypermedia.Hyperlink `rel:"repository" json:"repository_url,omitempty"`
+	RateLimitURL                hypermedia.Hyperlink `rel:"rate_limit" json:"rate_limit_url,omitempty"`
+	GistsURL                    hypermedia.Hyperlink `rel:"gists" json:"gists_url,omitempty"`
+	FollowingURL                hypermedia.Hyperlink `rel:"following" json:"following_url,omitempty"`
+	FeedsURL                    hypermedia.Hyperlink `rel:"feeds" json:"feeds_url,omitempty"`
+	EventsURL                   hypermedia.Hyperlink `rel:"events" json:"events_url,omitempty"`
+	EmojisURL                   hypermedia.Hyperlink `rel:"emojis" json:"emojis_url,omitempty"`
+	EmailsURL                   hypermedia.Hyperlink `rel:"emails" json:"emails_url,omitempty"`
+	AuthorizationsURL           hypermedia.Hyperlink `rel:"authorizations" json:"authorizations_url,omitempty"`
+	CurrentUserURL              hypermedia.Hyperlink `rel:"current_user" json:"current_user_url,omitempty"`
+	HubURL                      hypermedia.Hyperlink `rel:"hub" json:"hub_url,omitempty"`
+	IssueSearchURL              hypermedia.Hyperlink `rel:"issue_search" json:"issue_search_url,omitempty"`
+	IssuesURL                   hypermedia.Hyperlink `rel:"issues" json:"issues_url,omitempty"`
+	KeysURL                     hypermedia.Hyperlink `rel:"keys" json:"keys_url,omitempty"`
+	NotificationsURL            hypermedia.Hyperlink `rel:"notifications" json:"notifications_url,omitempty"`
+	OrganizationRepositoriesURL hypermedia.Hyperlink `rel:"organization_repositories" json:"organization_repositories_url,omitempty"`
+	OrganizationURL             hypermedia.Hyperlink `rel:"organization" json:"organization_url,omitempty"`
+	PublicGistsURL              hypermedia.Hyperlink `rel:"public_gists" json:"public_gists_url,omitempty"`
+	PullsURL                    hypermedia.Hyperlink `rel:"pulls" json:"-"`
+	rels                        hypermedia.Relations `json:"-"`
+}
+
+func (r *Root) Rels() hypermedia.Relations {
+	if r.rels == nil || len(r.rels) == 0 {
+		r.rels = hypermedia.HyperFieldDecoder(r)
+		for key, hyperlink := range r.HALResource.Rels() {
+			r.rels[key] = hyperlink
+		}
+	}
+	return r.rels
 }

--- a/octokit/root_test.go
+++ b/octokit/root_test.go
@@ -22,3 +22,17 @@ func TestRootService_One(t *testing.T) {
 	assert.T(t, !result.HasError())
 	assert.Equal(t, "https://api.github.com/users/{user}", string(root.UserURL))
 }
+
+func TestClientRel(t *testing.T) {
+	setup()
+	defer tearDown()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		respondWithJSON(w, loadFixture("root.json"))
+	})
+
+	u, err := client.Rel("user", M{"user": "root"})
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "https://api.github.com/users/root", u.String())
+}


### PR DESCRIPTION
`Rels()` is a hypermedia function to construct a URL given a string relation name and a map of uri template vars.  `client.Rels()` uses a cached root relations object.

Right now, the relations are cached for the lifetime of the go process.  This is fine until we have a solid http caching implementation.
