### PR TITLE
Quick spike on injecting Resource

### DIFF
--- a/octokit/client.go
+++ b/octokit/client.go
@@ -1,6 +1,7 @@
 package octokit
 
 import (
+	"github.com/codegangsta/inject"
 	"github.com/lostisland/go-sawyer"
 	"github.com/lostisland/go-sawyer/hypermedia"
 	"net/http"
@@ -56,6 +57,12 @@ func (c *Client) head(url *url.URL, output interface{}) (result *Result) {
 	return
 }
 
+func injectField(v interface{}, f interface{}) error {
+	injector := inject.New()
+	injector.Map(f)
+	return injector.Apply(v)
+}
+
 func (c *Client) get(url *url.URL, output interface{}) (result *Result) {
 	req, err := c.NewRequest(url.String())
 	if err != nil {
@@ -64,6 +71,13 @@ func (c *Client) get(url *url.URL, output interface{}) (result *Result) {
 	}
 
 	resp, err := req.Get(output)
+	e := injectField(output, NewResource())
+	if e != nil {
+		// panic if it's not a Octokit resource
+		// TODO: remove panic, use interface to ensure
+		panic(e)
+	}
+
 	result = newResult(resp, err)
 
 	return

--- a/octokit/client_test.go
+++ b/octokit/client_test.go
@@ -6,6 +6,15 @@ import (
 	"testing"
 )
 
+func TestInjectRels(t *testing.T) {
+	res := NewResource()
+	root := &Root{}
+	err := injectField(root, res)
+
+	assert.Equal(t, nil, err)
+	assert.Equal(t, res, root.Resource)
+}
+
 func TestSuccessfulGet(t *testing.T) {
 	setup()
 	defer tearDown()

--- a/octokit/root.go
+++ b/octokit/root.go
@@ -34,7 +34,8 @@ type RootService struct {
 }
 
 func (r *RootService) One() (root *Root, result *Result) {
-	result = r.client.get(r.URL, &root)
+	root = &Root{}
+	result = r.client.get(r.URL, root)
 	if root != nil {
 		// Cached hyperlinks
 		root.PullsURL = hypermedia.Hyperlink(PullRequestsURL)
@@ -44,8 +45,7 @@ func (r *RootService) One() (root *Root, result *Result) {
 }
 
 type Root struct {
-	*Resource
-
+	*Resource                   `inject`
 	UserSearchURL               hypermedia.Hyperlink `rel:"user_search" json:"user_search_url,omitempty"`
 	UserRepositoriesURL         hypermedia.Hyperlink `rel:"user_repositories" json:"user_repositories_url,omitempty"`
 	UserOrganizationsURL        hypermedia.Hyperlink `rel:"user_organizations" json:"user_organizations_url,omitempty"`
@@ -77,8 +77,5 @@ type Root struct {
 }
 
 func (r *Root) Rels() hypermedia.Relations {
-	if r.Resource == nil {
-		r.Resource = NewResource()
-	}
 	return r.Resource.RelsOf(r)
 }

--- a/octokit/root_test.go
+++ b/octokit/root_test.go
@@ -21,6 +21,7 @@ func TestRootService_One(t *testing.T) {
 	root, result := client.Root(url).One()
 	assert.T(t, !result.HasError())
 	assert.Equal(t, "https://api.github.com/users/{user}", string(root.UserURL))
+	assert.T(t, root.Resource != nil)
 }
 
 func TestClientRel(t *testing.T) {


### PR DESCRIPTION
It's not fully done. A quick idea on how Dependency Injection (DI) works in Go
This will clean up `Rels()` being implemented in all resources.
The ultimate goal is to remove all `Rels()` but only injecting `hypermedia.Relations`

I was planning to build a DI lib, but looks like there's [one decent enough](https://github.com/codegangsta/inject) we could take advantage of
