### PR TITLE
"Delete" is exported in clients.go

### DIFF
--- a/octokit/client.go
+++ b/octokit/client.go
@@ -95,7 +95,7 @@ func (c *Client) put(url *url.URL, input interface{}, output interface{}) (resul
 	return
 }
 
-func (c *Client) Delete(url *url.URL, output interface{}) (result *Result) {
+func (c *Client) delete(url *url.URL, output interface{}) (result *Result) {
 	req, err := c.NewRequest(url.String())
 	if err != nil {
 		result = newResult(nil, err)


### PR DESCRIPTION
In [octokit/client.go#L98](https://github.com/octokit/go-octokit/blob/master/octokit/client.go#L98) `Delete` is exported: 

`func (c *Client) Delete(url *url.URL, output interface{}) (result *Result)`

The other HTTP methods (post, head, get) are not, is this intentional or typo? 
