### PR TITLE
Add Netrc auth method

### DIFF
--- a/fixtures/example.netrc
+++ b/fixtures/example.netrc
@@ -1,0 +1,3 @@
+machine api.github.com
+  login catsby
+  password v5P6fghn7_a_fake_code_PGuelvbFaxBPkUg1ib

--- a/octokit/auth_method_test.go
+++ b/octokit/auth_method_test.go
@@ -10,6 +10,11 @@ func TestBasicAuth(t *testing.T) {
 	assert.Equal(t, "Basic amluZ3dlbm86cGFzc3dvcmQ=", basicAuth.String())
 }
 
+func TestNetrcAuth(t *testing.T) {
+	netrcAuth := NetrcAuth{NetrcPath: "../fixtures/example.netrc"}
+	assert.Equal(t, "Basic Y2F0c2J5OnY1UDZmZ2huN19hX2Zha2VfY29kZV9QR3VlbHZiRmF4QlBrVWcxaWI=", netrcAuth.String())
+}
+
 func TestTokenAuth(t *testing.T) {
 	tokenAuth := TokenAuth{AccessToken: "token"}
 	assert.Equal(t, "token token", tokenAuth.String())


### PR DESCRIPTION
Adds ability to authenticate with netrc.

This is my first patch to anything Go, I would love feedback here. Seems bad that I have to import 4 packages to accomplish this. Also the test seems right to me but I'm not sure. 

In writing this I found a lot of the [fields in the Users struct](https://github.com/octokit/go-octokit/blob/master/octokit/users.go#L44-L76) don't contain data, particularly the `int` ones. 

``` go
//octo.go
package main

import (
    "fmt"
    "github.com/catsby/go-octokit/octokit"
)

func main() {
    client := octokit.NewClient(octokit.NetrcAuth{})
    fmt.Println("Client: ", client)
    current_user_url, _ := octokit.CurrentUserURL.Expand(octokit.M{})
    user_service := client.Users(current_user_url)
    user, _ := user_service.One()
    fmt.Println("followers: ", user.Followers)
    fmt.Println("public gists: ", user.PublicGists)
}
```

Output: 

``` shell
go-octokit git:add_net_rc ❯ go run octo.go                                                                                                                                      
Client:  &{Octokit Go 0.3.0 Basic Y2F0c2**** map[]}
followers:  59
public gists:  0
```

I can file that as a separate bug if I'm not just doing something stupid. 
