### PR TITLE
Create relative hyperlinks.

### DIFF
--- a/octokit/authorizations.go
+++ b/octokit/authorizations.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	AuthorizationsURL = Hyperlink("/authorizations{/id}")
+	AuthorizationsURL = Hyperlink("authorizations{/id}")
 )
 
 // Create a AuthorizationsService with the base url.URL

--- a/octokit/issues.go
+++ b/octokit/issues.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	RepoIssuesURL = Hyperlink("/repos/{owner}/{repo}/issues{/number}")
+	RepoIssuesURL = Hyperlink("repos/{owner}/{repo}/issues{/number}")
 )
 
 // Create a IssuesService with the base url.URL

--- a/octokit/pull_requests.go
+++ b/octokit/pull_requests.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	PullRequestsURL = Hyperlink("/repos/{owner}/{repo}/pulls{/number}")
+	PullRequestsURL = Hyperlink("repos/{owner}/{repo}/pulls{/number}")
 )
 
 // Create a PullRequestsService with the base url.URL

--- a/octokit/releases.go
+++ b/octokit/releases.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	ReleasesURL = Hyperlink("/repos/{owner}/{repo}/releases{/id}")
+	ReleasesURL = Hyperlink("repos/{owner}/{repo}/releases{/id}")
 )
 
 type Release struct {

--- a/octokit/repositories.go
+++ b/octokit/repositories.go
@@ -7,10 +7,10 @@ import (
 )
 
 var (
-	RepositoryURL       = Hyperlink("/repos/{owner}/{repo}")
-	ForksURL            = Hyperlink("/repos/{owner}/{repo}/forks")
-	UserRepositoriesURL = Hyperlink("/user/repos")
-	OrgRepositoriesURL  = Hyperlink("/orgs/{org}/repos")
+	RepositoryURL       = Hyperlink("repos/{owner}/{repo}")
+	ForksURL            = Hyperlink("repos/{owner}/{repo}/forks")
+	UserRepositoriesURL = Hyperlink("user/repos")
+	OrgRepositoriesURL  = Hyperlink("orgs/{org}/repos")
 )
 
 // Create a RepositoriesService with the base url.URL

--- a/octokit/root.go
+++ b/octokit/root.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	RootURL = Hyperlink("/")
+	RootURL = Hyperlink("")
 )
 
 func (c *Client) Rel(name string, m map[string]interface{}) (*url.URL, error) {

--- a/octokit/statuses.go
+++ b/octokit/statuses.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	StatusesURL = Hyperlink("/repos/{owner}/{repo}/statuses/{ref}")
+	StatusesURL = Hyperlink("repos/{owner}/{repo}/statuses/{ref}")
 )
 
 // Create a StatusesService with the base url.URL

--- a/octokit/users.go
+++ b/octokit/users.go
@@ -7,8 +7,8 @@ import (
 )
 
 var (
-	CurrentUserURL = Hyperlink("/user")
-	UserURL        = Hyperlink("/users{/user}")
+	CurrentUserURL = Hyperlink("user")
+	UserURL        = Hyperlink("users{/user}")
 )
 
 // Create a UsersService with the base url.URL


### PR DESCRIPTION
This will preserve the urls for GitHub Enterprise.
Otherwise, Sawyer and Octokit remove the first part of the path when the api endpoint is `https://github.enterprise.com/api/v3`.

Depends on: https://github.com/lostisland/go-sawyer/pull/11
