### PR TITLE
Switch to GitHub mirror for go-netrc

### DIFF
--- a/gopack.config
+++ b/gopack.config
@@ -1,8 +1,8 @@
 repo = "github.com/octokit/go-octokit"
 
 [deps.netrc]
-import = "code.google.com/p/go-netrc/netrc"
-commit = "0da3cb9c37e0"
+import = "github.com/fhs/go-netrc/netrc"
+commit = "4422b68c9c934b03e8e53ef18c8c8714542def7e"
 
 [deps.sawyer]
 import = "github.com/lostisland/go-sawyer"

--- a/octokit/auth_method.go
+++ b/octokit/auth_method.go
@@ -1,9 +1,9 @@
 package octokit
 
 import (
-	"code.google.com/p/go-netrc/netrc"
 	"encoding/base64"
 	"fmt"
+	"github.com/fhs/go-netrc/netrc"
 	"net/url"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
Removes the dependency on `hg`. It appears this mirror is up to date, but if you prefer to keep the Google Code source for go-netrc, we need to add a check for `hg` in `script/bootstrap`.

/cc @jingweno 
