### PR TITLE
Trim space for multiple media type entries

### DIFF
--- a/octokit/octokit.go
+++ b/octokit/octokit.go
@@ -4,5 +4,5 @@ const (
 	gitHubAPIURL     = "https://api.github.com"
 	userAgent        = "Octokit Go " + version
 	version          = "0.3.0"
-	defaultMediaType = "application/vnd.github.v3+json; charset=utf-8"
+	defaultMediaType = "application/vnd.github.v3+json;charset=utf-8"
 )


### PR DESCRIPTION
Rack is strict about spaces between entries: https://github.com/rack/rack/blob/master/lib/rack/request.rb#L50-L60
