### PR TITLE
Always return *ResponseError in NewReesponseError

### DIFF
--- a/octokit/error.go
+++ b/octokit/error.go
@@ -2,11 +2,12 @@ package octokit
 
 import (
 	"fmt"
-	"github.com/lostisland/go-sawyer"
 	"io/ioutil"
 	"net/http"
 	"regexp"
 	"strings"
+
+	"github.com/lostisland/go-sawyer"
 )
 
 type ResponseErrorType int
@@ -95,17 +96,15 @@ func (e *ResponseError) errorMessage() string {
 	return strings.Join(messages, "\n")
 }
 
-func NewResponseError(resp *sawyer.Response) (err error) {
-	var respErr *ResponseError
-	t := getResponseErrorType(resp.Response)
-	err = resp.Decode(&respErr)
-	if err != nil {
-		return
-	}
+func NewResponseError(resp *sawyer.Response) (err *ResponseError) {
+	err = &ResponseError{}
+	err.Response = resp.Response
+	err.Type = getResponseErrorType(resp.Response)
 
-	respErr.Response = resp.Response
-	respErr.Type = t
-	err = respErr
+	e := resp.Decode(&err)
+	if e != nil {
+		err.Message = fmt.Sprintf("Problems parsing error message: %s", e)
+	}
 
 	return
 }

--- a/octokit/error_test.go
+++ b/octokit/error_test.go
@@ -1,11 +1,31 @@
 package octokit
 
 import (
-	"github.com/bmizerany/assert"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/bmizerany/assert"
 )
+
+func TestResponseError_empty_body(t *testing.T) {
+	setup()
+	defer tearDown()
+
+	mux.HandleFunc("/error", func(w http.ResponseWriter, r *http.Request) {
+		head := w.Header()
+		head.Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		respondWith(w, "")
+	})
+
+	req, _ := client.NewRequest("error")
+	_, err := req.Get(nil)
+	assert.Tf(t, strings.Contains(err.Error(), "400 - Problems parsing error message: EOF"), "%s", err.Error())
+
+	e := err.(*ResponseError)
+	assert.Equal(t, ErrorBadRequest, e.Type)
+}
 
 func TestResponseError_Error_400(t *testing.T) {
 	setup()


### PR DESCRIPTION
Previously it could happen that the response body can't be decoded and the
return error is a different type from *ResponseError. This causes downstream
usage to handle different types of errors.

The solution is to always return *ResponseError and make the decoding error as
part of the *ResponseError.
