### PR TITLE
Add `script/bootstrap` to install dependencies in `./_vendor`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.test
 .env
 .gopack
+_vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
+install: script/bootstrap
+script: script/test
 language: go
 go:
 - 1.3
-script: script/test

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Usage: script/bootstrap [--force]
+#
+# Installs necessary dependencies in `./_vendor` directory and keeps only
+# runtime files for them.
+
+set -e
+
+if [ "$1" = "--force" ]; then
+  rm -rf ./_vendor
+  shift 1
+fi
+
+export GOPATH="${PWD}/_vendor"
+
+# When current directory isn't under GOPATH, go install emits a non-fatal warning:
+# "no install location for directory <...> outside GOPATH"
+# Ignore this error, as everything works anyway.
+go get -t ./octokit/... 2> >(grep -v 'outside GOPATH$' >&2) || true
+
+# remove git repos
+find ./_vendor/src -type d -name .git -exec rm -rf {} +
+# remove non-runtime files
+find ./_vendor/src -type f -not -name '*.go' -not -iname 'license*' -exec rm {} +
+find ./_vendor/src -type f -name '*_test.go' -exec rm {} +
+# cleanup empty directories
+find ./_vendor/src -type d -empty -exec rmdir {} +

--- a/script/test
+++ b/script/test
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 # Usage: script/test
-#
-# Downloads dependencies and run tests
 
 set -e
 
-go get ./...
-go get github.com/bmizerany/assert
-go test ./...
+GOPATH="${PWD}/_vendor" go test ./octokit/...


### PR DESCRIPTION
This helps newcomers who might have cloned the repo into an environment where they haven't yet set up proper GOPATH structure, and enables them to run tests and hack on the project.

It is also a step towards vendoring all dependencies in git; hence the cleanup of unnecessary files. Ideally no bootstraping should be required when someone clones this project.

/cc @jingweno