### PR TITLE
Partial support for Git Trees API

### DIFF
--- a/fixtures/tree.json
+++ b/fixtures/tree.json
@@ -1,0 +1,77 @@
+{
+  "sha": "9c1337e761bbd517f3cc1b5acb9373b17f4810e8",
+  "url": "https://api.github.com/repos/pengwynn/flint/git/trees/9c1337e761bbd517f3cc1b5acb9373b17f4810e8",
+  "tree": [
+    {
+      "path": ".gitignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f47698acab5bb849abd6fed978760f47b6e03bea",
+      "size": 27,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/f47698acab5bb849abd6fed978760f47b6e03bea"
+    },
+    {
+      "path": ".travis.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "48fd403c6d23eb9856828fff1bf72fde47f956b9",
+      "size": 67,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/48fd403c6d23eb9856828fff1bf72fde47f956b9"
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f8f410dd9fee47b4390baff43e548470d3382616",
+      "size": 656,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/f8f410dd9fee47b4390baff43e548470d3382616"
+    },
+    {
+      "path": "LICENSE.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "77edd100f67a1a9b923eb26b3061a9c3d3137cdc",
+      "size": 1086,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/77edd100f67a1a9b923eb26b3061a9c3d3137cdc"
+    },
+    {
+      "path": "README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "75414323e54aea85bccd02953bd139652f557f3a",
+      "size": 4453,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/75414323e54aea85bccd02953bd139652f557f3a"
+    },
+    {
+      "path": "flint.go",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "836549a55bae146afd3b0fba5a30fb9b60142fc7",
+      "size": 2122,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/836549a55bae146afd3b0fba5a30fb9b60142fc7"
+    },
+    {
+      "path": "flint",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "c9e2169cca2ffd5041fbdcd99dd56ab6d965e8cf",
+      "url": "https://api.github.com/repos/pengwynn/flint/git/trees/c9e2169cca2ffd5041fbdcd99dd56ab6d965e8cf"
+    },
+    {
+      "path": "gopack.config",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1b938ab7fecfd4c6bfdd5056177427de695ce8e8",
+      "size": 243,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/1b938ab7fecfd4c6bfdd5056177427de695ce8e8"
+    },
+    {
+      "path": "script",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "78fb904f1d83e7e880241cc27853ee0b26dc4737",
+      "url": "https://api.github.com/repos/pengwynn/flint/git/trees/78fb904f1d83e7e880241cc27853ee0b26dc4737"
+    }
+  ],
+  "truncated": false
+}

--- a/fixtures/tree_recursive.json
+++ b/fixtures/tree_recursive.json
@@ -1,0 +1,125 @@
+{
+  "sha": "9c1337e761bbd517f3cc1b5acb9373b17f4810e8",
+  "url": "https://api.github.com/repos/pengwynn/flint/git/trees/9c1337e761bbd517f3cc1b5acb9373b17f4810e8",
+  "tree": [
+    {
+      "path": ".gitignore",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f47698acab5bb849abd6fed978760f47b6e03bea",
+      "size": 27,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/f47698acab5bb849abd6fed978760f47b6e03bea"
+    },
+    {
+      "path": ".travis.yml",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "48fd403c6d23eb9856828fff1bf72fde47f956b9",
+      "size": 67,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/48fd403c6d23eb9856828fff1bf72fde47f956b9"
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "f8f410dd9fee47b4390baff43e548470d3382616",
+      "size": 656,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/f8f410dd9fee47b4390baff43e548470d3382616"
+    },
+    {
+      "path": "LICENSE.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "77edd100f67a1a9b923eb26b3061a9c3d3137cdc",
+      "size": 1086,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/77edd100f67a1a9b923eb26b3061a9c3d3137cdc"
+    },
+    {
+      "path": "README.md",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "75414323e54aea85bccd02953bd139652f557f3a",
+      "size": 4453,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/75414323e54aea85bccd02953bd139652f557f3a"
+    },
+    {
+      "path": "flint.go",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "836549a55bae146afd3b0fba5a30fb9b60142fc7",
+      "size": 2122,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/836549a55bae146afd3b0fba5a30fb9b60142fc7"
+    },
+    {
+      "path": "flint",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "c9e2169cca2ffd5041fbdcd99dd56ab6d965e8cf",
+      "url": "https://api.github.com/repos/pengwynn/flint/git/trees/c9e2169cca2ffd5041fbdcd99dd56ab6d965e8cf"
+    },
+    {
+      "path": "flint/flint.go",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "b640c50c6aee12f2693a21c063644a13d87946dd",
+      "size": 1573,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/b640c50c6aee12f2693a21c063644a13d87946dd"
+    },
+    {
+      "path": "flint/flint_test.go",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "c7edaea959818de5ef97b95ae3c5071c5d209be2",
+      "size": 4670,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/c7edaea959818de5ef97b95ae3c5071c5d209be2"
+    },
+    {
+      "path": "gopack.config",
+      "mode": "100644",
+      "type": "blob",
+      "sha": "1b938ab7fecfd4c6bfdd5056177427de695ce8e8",
+      "size": 243,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/1b938ab7fecfd4c6bfdd5056177427de695ce8e8"
+    },
+    {
+      "path": "script",
+      "mode": "040000",
+      "type": "tree",
+      "sha": "78fb904f1d83e7e880241cc27853ee0b26dc4737",
+      "url": "https://api.github.com/repos/pengwynn/flint/git/trees/78fb904f1d83e7e880241cc27853ee0b26dc4737"
+    },
+    {
+      "path": "script/bootstrap",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "33240d9528b947f45b47f38bd95b8a76d4ba8bf0",
+      "size": 99,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/33240d9528b947f45b47f38bd95b8a76d4ba8bf0"
+    },
+    {
+      "path": "script/build",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "a05747d890bc081675deaa59d47a0602f133d954",
+      "size": 161,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/a05747d890bc081675deaa59d47a0602f133d954"
+    },
+    {
+      "path": "script/release",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "aaaf3463c970d5af2b58be4a365c5dd04e6880da",
+      "size": 387,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/aaaf3463c970d5af2b58be4a365c5dd04e6880da"
+    },
+    {
+      "path": "script/test",
+      "mode": "100755",
+      "type": "blob",
+      "sha": "8d200f7423909f94b813bf51efe2f40574c8f269",
+      "size": 54,
+      "url": "https://api.github.com/repos/pengwynn/flint/git/blobs/8d200f7423909f94b813bf51efe2f40574c8f269"
+    }
+  ],
+  "truncated": false
+}

--- a/octokit/git_trees.go
+++ b/octokit/git_trees.go
@@ -1,0 +1,39 @@
+package octokit
+
+import (
+	"net/url"
+)
+
+var GitTreesURL = Hyperlink("repos/{owner}/{repo}/git/trees/{/sha}{?recursive}")
+
+func (c *Client) GitTrees(url *url.URL) (trees *GitTreesService) {
+	trees = &GitTreesService{client: c, URL: url}
+	return
+}
+
+type GitTreesService struct {
+	client *Client
+	URL    *url.URL
+}
+
+// Get a Git Tree
+func (c *GitTreesService) One() (tree *GitTree, result *Result) {
+	result = c.client.get(c.URL, &tree)
+	return
+}
+
+type GitTree struct {
+	Sha       string         `json:"sha,omitempty"`
+	Tree      []GitTreeEntry `json:"tree,omitempty"`
+	Truncated bool           `json:"truncated,omitempty"`
+	URL       string         `json:"url,omitempty"`
+}
+
+type GitTreeEntry struct {
+	Mode string `json:"mode,omitempty"`
+	Path string `json:"path,omitempty"`
+	Sha  string `json:"sha,omitempty"`
+	Size int    `json:"size,omitempty"`
+	Type string `json:"type,omitempty"`
+	URL  string `json:"url,omitempty"`
+}

--- a/octokit/git_trees_test.go
+++ b/octokit/git_trees_test.go
@@ -1,0 +1,59 @@
+package octokit
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+func TestGitTreesService_One(t *testing.T) {
+	setup()
+	defer tearDown()
+
+	mux.HandleFunc("/repos/pengwynn/flint/git/trees/master", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		respondWithJSON(w, loadFixture("tree.json"))
+	})
+
+	url, err := GitTreesURL.Expand(M{
+		"owner": "pengwynn",
+		"repo":  "flint",
+		"sha":   "master",
+	})
+	assert.Equal(t, nil, err)
+	tree, result := client.GitTrees(url).One()
+
+	assert.T(t, !result.HasError())
+	assert.Equal(t, "9c1337e761bbd517f3cc1b5acb9373b17f4810e8", tree.Sha)
+	assert.Equal(t, "https://api.github.com/repos/pengwynn/flint/git/trees/9c1337e761bbd517f3cc1b5acb9373b17f4810e8", tree.URL)
+
+	entries := tree.Tree
+	assert.Equal(t, 9, len(entries))
+}
+
+func TestGitTreesService_One_Recursive(t *testing.T) {
+	setup()
+	defer tearDown()
+
+	mux.HandleFunc("/repos/pengwynn/flint/git/trees/master", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		respondWithJSON(w, loadFixture("tree_recursive.json"))
+	})
+
+	url, err := GitTreesURL.Expand(M{
+		"owner":     "pengwynn",
+		"repo":      "flint",
+		"sha":       "master",
+		"recursive": "1",
+	})
+	assert.Equal(t, nil, err)
+	tree, result := client.GitTrees(url).One()
+
+	assert.T(t, !result.HasError())
+	assert.Equal(t, "9c1337e761bbd517f3cc1b5acb9373b17f4810e8", tree.Sha)
+	assert.Equal(t, "https://api.github.com/repos/pengwynn/flint/git/trees/9c1337e761bbd517f3cc1b5acb9373b17f4810e8", tree.URL)
+
+	entries := tree.Tree
+	assert.Equal(t, 15, len(entries))
+}


### PR DESCRIPTION
I needed to fetch Git trees in another project. This PR adds support for [getting a tree](https://developer.github.com/v3/git/trees/#get-a-tree) via the API.

/cc @jingweno 
