### PR TITLE
Allow parsing null pushed_at

### DIFF
--- a/fixtures/repositories.json
+++ b/fixtures/repositories.json
@@ -71,7 +71,7 @@
     "releases_url": "https://api.github.com/repos/rails/rails/releases{/id}",
     "created_at": "2008-04-11T02:19:47Z",
     "updated_at": "2013-11-01T12:46:28Z",
-    "pushed_at": "2013-11-01T12:45:22Z",
+    "pushed_at": null,
     "git_url": "git://github.com/rails/rails.git",
     "ssh_url": "git@github.com:rails/rails.git",
     "clone_url": "https://github.com/rails/rails.git",

--- a/octokit/repositories.go
+++ b/octokit/repositories.go
@@ -66,7 +66,7 @@ type Repository struct {
 	Size          int           `json:"size,omitempty"`
 	MasterBranch  string        `json:"master_branch,omitempty"`
 	OpenIssues    int           `json:"open_issues,omitempty"`
-	PushedAt      time.Time     `json:"pushed_at,omitempty"`
+	PushedAt      *time.Time    `json:"pushed_at,omitempty"`
 	CreatedAt     time.Time     `json:"created_at,omitempty"`
 	UpdatedAt     time.Time     `json:"updated_at,omitempty"`
 	Permissions   Permissions   `json:"permissions,omitempty"`


### PR DESCRIPTION
Repository's pushed_at ia an attribute which can be null. If it is null, you'll get a following error message.

```
parsing time "null" as ""2006-01-02T15:04:05Z07:00"": cannot parse "null" as """
```

I changed the test to fail for such a situation and passed by changing PushedAt to be a pointer.