### PR TITLE
Change the octokit test to use filepath instead of path.

### DIFF
--- a/octokit/octokit_test.go
+++ b/octokit/octokit_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -118,7 +118,7 @@ func testURLStringOf(path string) string {
 
 func loadFixture(f string) string {
 	pwd, _ := os.Getwd()
-	p := path.Join(pwd, "..", "fixtures", f)
+	p := filepath.Join(pwd, "..", "fixtures", f)
 	c, _ := ioutil.ReadFile(p)
 	return string(c)
 }


### PR DESCRIPTION
According to the golang documentation of path and filepath, path "implements utility routines for manipulating slash-separated paths," while filepath "implements utility routines for manipulating filename paths in a way compatible with the target operating system-defined file paths." The use of path caused the test to fail on Windows.