### PR TITLE
HTTP stub helpers

### DIFF
--- a/octokit/authorizations_test.go
+++ b/octokit/authorizations_test.go
@@ -13,10 +13,7 @@ func TestAuthorizationsService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/authorizations/1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("authorization.json"))
-	})
+	stubGet(t, "/authorizations/1", "authorization", nil)
 
 	url, err := AuthorizationsURL.Expand(M{"id": 1})
 	assert.NoError(t, err)
@@ -44,10 +41,7 @@ func TestAuthorizationsService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/authorizations", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("authorizations.json"))
-	})
+	stubGet(t, "/authorizations", "authorizations", nil)
 
 	url, err := AuthorizationsURL.Expand(nil)
 	assert.NoError(t, err)

--- a/octokit/commits_test.go
+++ b/octokit/commits_test.go
@@ -12,10 +12,7 @@ func TestCommitsService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/octokit/go-octokit/commits/4351fb69b8d5ed075e9cd844e67ad2114b335c82", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("commit.json"))
-	})
+	stubGet(t, "/repos/octokit/go-octokit/commits/4351fb69b8d5ed075e9cd844e67ad2114b335c82", "commit", nil)
 
 	url, err := CommitsURL.Expand(M{
 		"owner": "octokit",

--- a/octokit/emojis_test.go
+++ b/octokit/emojis_test.go
@@ -10,7 +10,7 @@ func TestRootEmojisService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	stubGet(t, "/emojis", "emojis")
+	stubGet(t, "/emojis", "emojis", nil)
 
 	url, err := EmojisURL.Expand(nil)
 	assert.NoError(t, err)

--- a/octokit/emojis_test.go
+++ b/octokit/emojis_test.go
@@ -1,7 +1,6 @@
 package octokit
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,10 +10,7 @@ func TestRootEmojisService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/emojis", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("emojis.json"))
-	})
+	stubGet(t, "/emojis", "emojis")
 
 	url, err := EmojisURL.Expand(nil)
 	assert.NoError(t, err)

--- a/octokit/gists_test.go
+++ b/octokit/gists_test.go
@@ -12,10 +12,7 @@ func TestGistsService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/gists/a6bea192debdbec0d4ab", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("gist.json"))
-	})
+	stubGet(t, "/gists/a6bea192debdbec0d4ab", "gist", nil)
 
 	url, _ := GistsURL.Expand(M{"gist_id": "a6bea192debdbec0d4ab"})
 	gist, result := client.Gists(url).One()
@@ -37,10 +34,7 @@ func TestGistsService_Raw(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/gists/a6bea192debdbec0d4ab", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("gist.json"))
-	})
+	stubGet(t, "/gists/a6bea192debdbec0d4ab", "gist", nil)
 
 	mux.HandleFunc("/jingweno/a6bea192debdbec0d4ab/raw/80757419d2bd4cfddf7c6be24308eca11b3c330e/grep_cellar", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/octokit/git_trees_test.go
+++ b/octokit/git_trees_test.go
@@ -1,7 +1,6 @@
 package octokit
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,10 +10,7 @@ func TestGitTreesService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/pengwynn/flint/git/trees/master", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("tree.json"))
-	})
+	stubGet(t, "/repos/pengwynn/flint/git/trees/master", "tree", nil)
 
 	url, err := GitTreesURL.Expand(M{
 		"owner": "pengwynn",
@@ -36,10 +32,7 @@ func TestGitTreesService_One_Recursive(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/pengwynn/flint/git/trees/master", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("tree_recursive.json"))
-	})
+	stubGet(t, "/repos/pengwynn/flint/git/trees/master", "tree_recursive", nil)
 
 	url, err := GitTreesURL.Expand(M{
 		"owner":     "pengwynn",

--- a/octokit/issues_test.go
+++ b/octokit/issues_test.go
@@ -12,10 +12,7 @@ func TestIssuesService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/octocat/Hello-World/issues", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("issues.json"))
-	})
+	stubGet(t, "/repos/octocat/Hello-World/issues", "issues", nil)
 
 	url, err := RepoIssuesURL.Expand(M{"owner": "octocat", "repo": "Hello-World"})
 	assert.NoError(t, err)
@@ -32,10 +29,7 @@ func TestIssuesService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/octocat/Hello-World/issues/1347", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("issue.json"))
-	})
+	stubGet(t, "/repos/octocat/Hello-World/issues/1347", "issue", nil)
 
 	url, err := RepoIssuesURL.Expand(M{"owner": "octocat", "repo": "Hello-World", "number": 1347})
 	assert.NoError(t, err)

--- a/octokit/octokit_test.go
+++ b/octokit/octokit_test.go
@@ -122,3 +122,14 @@ func loadFixture(f string) string {
 	c, _ := ioutil.ReadFile(p)
 	return string(c)
 }
+
+func stubGet(t *testing.T, path, fixture string) {
+	stubRequest(t, "GET", path, fixture)
+}
+
+func stubRequest(t *testing.T, method string, path string, fixture string) {
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, method)
+		respondWithJSON(w, loadFixture(fixture+".json"))
+	})
+}

--- a/octokit/octokit_test.go
+++ b/octokit/octokit_test.go
@@ -123,13 +123,23 @@ func loadFixture(f string) string {
 	return string(c)
 }
 
-func stubGet(t *testing.T, path, fixture string) {
-	stubRequest(t, "GET", path, fixture)
+func stubGet(t *testing.T, path, fixture string, params map[string]string) {
+	stubRequest(t, "GET", path, fixture, params)
 }
 
-func stubRequest(t *testing.T, method string, path string, fixture string) {
+func stubRequest(t *testing.T, method string, path string, fixture string, params map[string]string) {
+	if mux == nil {
+		panic(fmt.Errorf("test HTTP server has not been set up"))
+	}
+
 	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, method)
+		if params != nil {
+			header := w.Header()
+			for k, v := range params {
+				header.Set(k, v)
+			}
+		}
 		respondWithJSON(w, loadFixture(fixture+".json"))
 	})
 }

--- a/octokit/pull_requests_test.go
+++ b/octokit/pull_requests_test.go
@@ -13,10 +13,7 @@ func TestPullRequestService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/octokit/go-octokit/pulls/1", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("pull_request.json"))
-	})
+	stubGet(t, "/repos/octokit/go-octokit/pulls/1", "pull_request", nil)
 
 	url, err := PullRequestsURL.Expand(M{"owner": "octokit", "repo": "go-octokit", "number": 1})
 	assert.NoError(t, err)
@@ -101,13 +98,8 @@ func TestPullRequestService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/rails/rails/pulls", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		header := w.Header()
-		link := fmt.Sprintf(`<%s>; rel="next", <%s>; rel="last"`, testURLOf("repositories/8514/pulls?page=2"), testURLOf("repositories/8514/pulls?page=14"))
-		header.Set("Link", link)
-		respondWithJSON(w, loadFixture("pull_requests.json"))
-	})
+	link := fmt.Sprintf(`<%s>; rel="next", <%s>; rel="last"`, testURLOf("repositories/8514/pulls?page=2"), testURLOf("repositories/8514/pulls?page=14"))
+	stubGet(t, "/repos/rails/rails/pulls", "pull_requests", map[string]string{"Link": link})
 
 	url, err := PullRequestsURL.Expand(M{"owner": "rails", "repo": "rails"})
 	assert.NoError(t, err)

--- a/octokit/releases_test.go
+++ b/octokit/releases_test.go
@@ -11,10 +11,7 @@ func TestReleasesService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/jingweno/gh/releases", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("releases.json"))
-	})
+	stubGet(t, "/repos/jingweno/gh/releases", "releases", nil)
 
 	url, err := ReleasesURL.Expand(M{"owner": "jingweno", "repo": "gh"})
 	assert.NoError(t, err)

--- a/octokit/repositories_test.go
+++ b/octokit/repositories_test.go
@@ -13,10 +13,7 @@ func TestRepositoresService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/jingweno/octokat", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("repository.json"))
-	})
+	stubGet(t, "/repos/jingweno/octokat", "repository", nil)
 
 	url, err := RepositoryURL.Expand(M{"owner": "jingweno", "repo": "octokat"})
 	assert.NoError(t, err)
@@ -45,15 +42,8 @@ func TestRepositoresService_All(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/orgs/rails/repos", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-
-		header := w.Header()
-		link := fmt.Sprintf(`<%s>; rel="next", <%s>; rel="last"`, testURLOf("organizations/4223/repos?page=2"), testURLOf("organizations/4223/repos?page=3"))
-		header.Set("Link", link)
-
-		respondWithJSON(w, loadFixture("repositories.json"))
-	})
+	link := fmt.Sprintf(`<%s>; rel="next", <%s>; rel="last"`, testURLOf("organizations/4223/repos?page=2"), testURLOf("organizations/4223/repos?page=3"))
+	stubGet(t, "/orgs/rails/repos", "repositories", map[string]string{"Link": link})
 
 	url, err := OrgRepositoriesURL.Expand(M{"org": "rails"})
 	assert.NoError(t, err)

--- a/octokit/root_test.go
+++ b/octokit/root_test.go
@@ -1,7 +1,6 @@
 package octokit
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,10 +10,7 @@ func TestRootService_One(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("root.json"))
-	})
+	stubGet(t, "/", "root", nil)
 
 	url, err := RootURL.Expand(nil)
 	assert.NoError(t, err)
@@ -28,10 +24,7 @@ func TestClientRel(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("root.json"))
-	})
+	stubGet(t, "/", "root", nil)
 
 	u, err := client.Rel("user", M{"user": "root"})
 	assert.NoError(t, err)

--- a/octokit/search_test.go
+++ b/octokit/search_test.go
@@ -1,7 +1,6 @@
 package octokit
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,10 +10,7 @@ func TestSearchService_Users(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/search/users", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("user_search.json"))
-	})
+	stubGet(t, "/search/users", "user_search", nil)
 
 	url, err := SearchURL.Expand(map[string]interface{}{
 		"type":  "users",
@@ -37,11 +33,7 @@ func TestSearchService_Issues(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/search/issues", func(w http.ResponseWriter,
-		r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("issue_search.json"))
-	})
+	stubGet(t, "/search/issues", "issue_search", nil)
 
 	url, err := SearchURL.Expand(map[string]interface{}{
 		"type":  "issues",
@@ -63,11 +55,7 @@ func TestSearchService_Repositories(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/search/repositories", func(w http.ResponseWriter,
-		r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("repository_search.json"))
-	})
+	stubGet(t, "/search/repositories", "repository_search", nil)
 
 	url, err := SearchURL.Expand(map[string]interface{}{
 		"type":  "repositories",
@@ -90,11 +78,7 @@ func TestSearchService_Code(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/search/code", func(w http.ResponseWriter,
-		r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("code_search.json"))
-	})
+	stubGet(t, "/search/code", "code_search", nil)
 
 	url, err := SearchURL.Expand(map[string]interface{}{
 		"type":  "code",

--- a/octokit/statuses_test.go
+++ b/octokit/statuses_test.go
@@ -1,7 +1,6 @@
 package octokit
 
 import (
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,10 +10,7 @@ func TestStatuses(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/jingweno/gh/statuses/740211b9c6cd8e526a7124fe2b33115602fbc637", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("statuses.json"))
-	})
+	stubGet(t, "/repos/jingweno/gh/statuses/740211b9c6cd8e526a7124fe2b33115602fbc637", "statuses", nil)
 
 	sha := "740211b9c6cd8e526a7124fe2b33115602fbc637"
 	url, err := StatusesURL.Expand(M{"owner": "jingweno", "repo": "gh", "ref": sha})

--- a/octokit/users_test.go
+++ b/octokit/users_test.go
@@ -13,10 +13,7 @@ func TestUsersService_GetCurrentUser(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("user.json"))
-	})
+	stubGet(t, "/user", "user", nil)
 
 	url, _ := CurrentUserURL.Expand(nil)
 	user, result := client.Users(url).One()
@@ -59,10 +56,7 @@ func TestUsersService_GetUser(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/users/jingweno", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithJSON(w, loadFixture("user.json"))
-	})
+	stubGet(t, "/users/jingweno", "user", nil)
 
 	url, err := UserURL.Expand(M{"user": "jingweno"})
 	assert.NoError(t, err)


### PR DESCRIPTION
Inspired by [Octokit.rb's stub helpers][helpers], this is a work-in-progress proof-of-concept for removing some noise from our tests. We can have our :cake: and eat it, too, because you can always do the more verbose approach if you need to.

Before we get too far, I wanted to see what @jingweno thinks of the approach.

/cc @obsc @dhruvsinghal @dhs252 

[helpers]: https://github.com/octokit/octokit.rb/blob/568745f0a612971207dd4d05ccbf0af821bdbb36/spec/helper.rb#L121-L170