### PR TITLE
Add Assignee to pull requests

### DIFF
--- a/fixtures/pull_request.json
+++ b/fixtures/pull_request.json
@@ -35,7 +35,13 @@
   "issue_url": "https://github.com/jingweno/octokat/pull/1",
   "number": 1,
   "state": "closed",
-  "assignee": null,
+  "assignee": {
+    "login": "octocat",
+    "id": 1,
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "somehexcode",
+    "url": "https://api.github.com/users/octocat"
+  },
   "milestone": null,
   "commits_url": "https://github.com/jingweno/octokat/pull/1/commits",
   "review_comments_url": "https://github.com/jingweno/octokat/pull/1/comments",

--- a/octokit/pull_requests.go
+++ b/octokit/pull_requests.go
@@ -91,10 +91,11 @@ type PullRequestCommit struct {
 }
 
 type PullRequestParams struct {
-	Base  string `json:"base,omitempty"`
-	Head  string `json:"head,omitempty"`
-	Title string `json:"title,omitempty"`
-	Body  string `json:"body,omitempty"`
+	Base     string `json:"base,omitempty"`
+	Head     string `json:"head,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Body     string `json:"body,omitempty"`
+	Assignee string `json:"assignee,omitempty"`
 }
 
 type PullRequestForIssueParams struct {

--- a/octokit/pull_requests_test.go
+++ b/octokit/pull_requests_test.go
@@ -42,7 +42,13 @@ func TestPullRequestService_One(t *testing.T) {
 	assert.Equal(t, "https://github.com/jingweno/octokat/pull/1", pr.IssueURL)
 	assert.Equal(t, 1, pr.Number)
 	assert.Equal(t, "closed", pr.State)
-	assert.Nil(t, pr.Assignee)
+
+	assert.Equal(t, "octocat", pr.Assignee.Login)
+	assert.Equal(t, 1, pr.Assignee.ID)
+	assert.Equal(t, "https://github.com/images/error/octocat_happy.gif", pr.Assignee.AvatarURL)
+	assert.Equal(t, "somehexcode", pr.Assignee.GravatarID)
+	assert.Equal(t, "https://api.github.com/users/octocat", pr.Assignee.URL)
+
 	assert.Equal(t, "https://github.com/jingweno/octokat/pull/1/commits", pr.CommitsURL)
 	assert.Equal(t, "https://github.com/jingweno/octokat/pull/1/comments", pr.ReviewCommentsURL)
 	assert.Equal(t, "/repos/jingweno/octokat/pulls/comments/{number}", pr.ReviewCommentURL)
@@ -56,7 +62,7 @@ func TestPullRequestService_Post(t *testing.T) {
 	mux.HandleFunc("/repos/octokit/go-octokit/pulls", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testBody(t, r,
-			"{\"base\":\"base\",\"head\":\"head\",\"title\":\"title\",\"body\":\"body\"}\n")
+			"{\"base\":\"base\",\"head\":\"head\",\"title\":\"title\",\"body\":\"body\",\"assignee\":\"assignee\"}\n")
 		respondWithJSON(w, loadFixture("pull_request.json"))
 	})
 
@@ -64,10 +70,11 @@ func TestPullRequestService_Post(t *testing.T) {
 	assert.NoError(t, err)
 
 	params := PullRequestParams{
-		Base:  "base",
-		Head:  "head",
-		Title: "title",
-		Body:  "body",
+		Base:     "base",
+		Head:     "head",
+		Title:    "title",
+		Body:     "body",
+		Assignee: "assignee",
 	}
 	pr, result := client.PullRequests(url).Create(params)
 
@@ -90,7 +97,13 @@ func TestPullRequestService_Post(t *testing.T) {
 	assert.Equal(t, "https://github.com/jingweno/octokat/pull/1", pr.IssueURL)
 	assert.Equal(t, 1, pr.Number)
 	assert.Equal(t, "closed", pr.State)
-	assert.Nil(t, pr.Assignee)
+
+	assert.Equal(t, "octocat", pr.Assignee.Login)
+	assert.Equal(t, 1, pr.Assignee.ID)
+	assert.Equal(t, "https://github.com/images/error/octocat_happy.gif", pr.Assignee.AvatarURL)
+	assert.Equal(t, "somehexcode", pr.Assignee.GravatarID)
+	assert.Equal(t, "https://api.github.com/users/octocat", pr.Assignee.URL)
+
 	assert.Equal(t, "https://github.com/jingweno/octokat/pull/1/commits", pr.CommitsURL)
 	assert.Equal(t, "https://github.com/jingweno/octokat/pull/1/comments", pr.ReviewCommentsURL)
 	assert.Equal(t, "/repos/jingweno/octokat/pulls/comments/{number}", pr.ReviewCommentURL)


### PR DESCRIPTION
As pull requests [shares the Issues API](https://developer.github.com/v3/pulls/#labels-assignees-and-milestones), this should be a fairly simple addition.

I can fill out the other missing parts -- milestones and labels -- from the issues API as well, if needed.