### PR TITLE
test Assert method usage is reversed - now fixed

### DIFF
--- a/octokit/emojis_test.go
+++ b/octokit/emojis_test.go
@@ -19,6 +19,6 @@ func TestRootEmojisService_All(t *testing.T) {
 	assert.False(t, result.HasError())
 	var penguin = "https://github.global.ssl.fastly.net/images/icons/emoji/penguin.png?v5"
 	var metal = "https://github.global.ssl.fastly.net/images/icons/emoji/metal.png?v5"
-	assert.Equal(t, emojis["penguin"], penguin)
-	assert.Equal(t, emojis["metal"], metal)
+	assert.Equal(t, penguin, emojis["penguin"])
+	assert.Equal(t, metal, emojis["metal"])
 }

--- a/octokit/emojis_test.go
+++ b/octokit/emojis_test.go
@@ -19,6 +19,6 @@ func TestRootEmojisService_All(t *testing.T) {
 	assert.False(t, result.HasError())
 	var penguin = "https://github.global.ssl.fastly.net/images/icons/emoji/penguin.png?v5"
 	var metal = "https://github.global.ssl.fastly.net/images/icons/emoji/metal.png?v5"
-	assert.Equal(t, penguin, emojis["penguin"])
-	assert.Equal(t, metal, emojis["metal"])
+	assert.Equal(t, emojis["penguin"], penguin)
+	assert.Equal(t, emojis["metal"], metal)
 }

--- a/octokit/search_test.go
+++ b/octokit/search_test.go
@@ -21,12 +21,12 @@ func TestSearchService_Users(t *testing.T) {
 
 	assert.False(t, result.HasError())
 	assert.False(t, searchResults.IncompleteResults)
-	assert.Equal(t, searchResults.TotalCount, 2)
-	assert.Equal(t, len(searchResults.Items), 2)
-	assert.Equal(t, searchResults.Items[0].ID, 3338555)
-	assert.Equal(t, searchResults.Items[0].Login, "dhruvsinghal")
-	assert.Equal(t, searchResults.Items[1].ID, 9294878)
-	assert.Equal(t, searchResults.Items[1].Login, "dhruvsinghal5")
+	assert.Equal(t, 2, searchResults.TotalCount)
+	assert.Equal(t, 2, len(searchResults.Items))
+	assert.Equal(t, 3338555, searchResults.Items[0].ID)
+	assert.Equal(t, "dhruvsinghal", searchResults.Items[0].Login)
+	assert.Equal(t, 9294878, searchResults.Items[1].ID)
+	assert.Equal(t, "dhruvsinghal5", searchResults.Items[1].Login)
 }
 
 func TestSearchService_Issues(t *testing.T) {
@@ -44,11 +44,11 @@ func TestSearchService_Issues(t *testing.T) {
 
 	assert.False(t, result.HasError())
 	assert.False(t, searchResults.IncompleteResults)
-	assert.Equal(t, searchResults.TotalCount, 180172)
-	assert.Equal(t, searchResults.Items[0].Number, 1551)
-	assert.Equal(t, searchResults.Items[0].Title, "Colorizer")
-	assert.Equal(t, searchResults.Items[1].Number, 3402)
-	assert.Equal(t, searchResults.Items[1].Title, "Colorizer")
+	assert.Equal(t, 180172, searchResults.TotalCount)
+	assert.Equal(t, 1551, searchResults.Items[0].Number)
+	assert.Equal(t, "Colorizer", searchResults.Items[0].Title)
+	assert.Equal(t, 3402, searchResults.Items[1].Number)
+	assert.Equal(t, "Colorizer", searchResults.Items[1].Title)
 }
 
 func TestSearchService_Repositories(t *testing.T) {
@@ -66,12 +66,12 @@ func TestSearchService_Repositories(t *testing.T) {
 
 	assert.False(t, result.HasError())
 	assert.False(t, searchResults.IncompleteResults)
-	assert.Equal(t, searchResults.TotalCount, 21)
-	assert.Equal(t, len(searchResults.Items), 21)
-	assert.Equal(t, searchResults.Items[0].ID, 8269299)
-	assert.Equal(t, searchResults.Items[0].FullName, "ysai/asdfghjk")
-	assert.Equal(t, searchResults.Items[1].ID, 8511889)
-	assert.Equal(t, searchResults.Items[1].FullName, "ines949494/ikadasd")
+	assert.Equal(t, 21, searchResults.TotalCount)
+	assert.Equal(t, 21, len(searchResults.Items))
+	assert.Equal(t, 8269299, searchResults.Items[0].ID)
+	assert.Equal(t, "ysai/asdfghjk", searchResults.Items[0].FullName)
+	assert.Equal(t, 8511889, searchResults.Items[1].ID)
+	assert.Equal(t, "ines949494/ikadasd", searchResults.Items[1].FullName)
 }
 
 func TestSearchService_Code(t *testing.T) {
@@ -89,19 +89,19 @@ func TestSearchService_Code(t *testing.T) {
 
 	assert.False(t, result.HasError())
 	assert.False(t, searchResults.IncompleteResults)
-	assert.Equal(t, searchResults.TotalCount, 7)
-	assert.Equal(t, len(searchResults.Items), 7)
-	assert.Equal(t, searchResults.Items[0].Name, "classes.js")
-	assert.Equal(t, searchResults.Items[0].Path, "src/attributes/classes.js")
-	assert.Equal(t, searchResults.Items[0].SHA,
-		"f9dba94f7de43d6b6b7256e05e0d17c4741a4cde")
-	assert.Equal(t, string(searchResults.Items[0].URL),
-		"https://api.github.com/repositories/167174/contents/src/attributes/classes.js?ref=53aa87f3bf4284763405f3eb8affff296e55ba4f")
-	assert.Equal(t, searchResults.Items[0].GitURL,
-		"https://api.github.com/repositories/167174/git/blobs/f9dba94f7de43d6b6b7256e05e0d17c4741a4cde")
-	assert.Equal(t, searchResults.Items[0].HTMLURL,
-		"https://github.com/jquery/jquery/blob/53aa87f3bf4284763405f3eb8affff296e55ba4f/src/attributes/classes.js")
-	assert.Equal(t, searchResults.Items[0].Repository.ID, 167174)
-	assert.Equal(t, searchResults.Items[0].Repository.FullName,
-		"jquery/jquery")
+	assert.Equal(t, 7, searchResults.TotalCount)
+	assert.Equal(t, 7, len(searchResults.Items))
+	assert.Equal(t, "classes.js", searchResults.Items[0].Name)
+	assert.Equal(t, "src/attributes/classes.js", searchResults.Items[0].Path)
+	assert.Equal(t,
+		"f9dba94f7de43d6b6b7256e05e0d17c4741a4cde", searchResults.Items[0].SHA)
+	assert.Equal(t,
+		"https://api.github.com/repositories/167174/contents/src/attributes/classes.js?ref=53aa87f3bf4284763405f3eb8affff296e55ba4f", string(searchResults.Items[0].URL))
+	assert.Equal(t,
+		"https://api.github.com/repositories/167174/git/blobs/f9dba94f7de43d6b6b7256e05e0d17c4741a4cde", searchResults.Items[0].GitURL)
+	assert.Equal(t,
+		"https://github.com/jquery/jquery/blob/53aa87f3bf4284763405f3eb8affff296e55ba4f/src/attributes/classes.js", searchResults.Items[0].HTMLURL)
+	assert.Equal(t, 167174, searchResults.Items[0].Repository.ID)
+	assert.Equal(t,
+		"jquery/jquery", searchResults.Items[0].Repository.FullName)
 }


### PR DESCRIPTION
Just a couple of the more recent test cases had this problem.
The error message would have the "expected" and "actual" values reversed if the tests were to break.
