### PR TITLE
Refactor uri expansion

### DIFF
--- a/octokit/commit_comments.go
+++ b/octokit/commit_comments.go
@@ -25,12 +25,8 @@ type CommitCommentsService struct {
 }
 
 // Get a list of all commit comments
-func (c *CommitCommentsService) All(uri *Hyperlink, params M) (comments []CommitComment, result *Result) {
-	if uri == nil {
-		uri = &RepoCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *CommitCommentsService) All(uri *Hyperlink, uriParams M) (comments []CommitComment, result *Result) {
+	url, err := ExpandWithDefault(uri, &RepoCommentsURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
@@ -40,12 +36,8 @@ func (c *CommitCommentsService) All(uri *Hyperlink, params M) (comments []Commit
 }
 
 // Get a single comment by id
-func (c *CommitCommentsService) One(uri *Hyperlink, params M) (comment *CommitComment, result *Result) {
-	if uri == nil {
-		uri = &RepoCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *CommitCommentsService) One(uri *Hyperlink, uriParams M) (comment *CommitComment, result *Result) {
+	url, err := ExpandWithDefault(uri, &RepoCommentsURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
@@ -55,42 +47,30 @@ func (c *CommitCommentsService) One(uri *Hyperlink, params M) (comment *CommitCo
 }
 
 // Creates a comment on a commit
-func (c *CommitCommentsService) Create(uri *Hyperlink, params M, input interface{}) (comment *CommitComment, result *Result) {
-	if uri == nil {
-		uri = &CommitCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *CommitCommentsService) Create(uri *Hyperlink, uriParams M, requestParams interface{}) (comment *CommitComment, result *Result) {
+	url, err := ExpandWithDefault(uri, &CommitCommentsURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
 
-	result = c.client.post(url, input, &comment)
+	result = c.client.post(url, requestParams, &comment)
 	return
 }
 
 // Updates a comment on a commit
-func (c *CommitCommentsService) Update(uri *Hyperlink, params M, input interface{}) (comment *CommitComment, result *Result) {
-	if uri == nil {
-		uri = &RepoCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *CommitCommentsService) Update(uri *Hyperlink, uriParams M, requestParams interface{}) (comment *CommitComment, result *Result) {
+	url, err := ExpandWithDefault(uri, &RepoCommentsURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
 
-	result = c.client.patch(url, input, &comment)
+	result = c.client.patch(url, requestParams, &comment)
 	return
 }
 
 // Deletes a comment on a commit
-func (c *CommitCommentsService) Delete(uri *Hyperlink, params M) (success bool, result *Result) {
-	if uri == nil {
-		uri = &RepoCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *CommitCommentsService) Delete(uri *Hyperlink, uriParams M) (success bool, result *Result) {
+	url, err := ExpandWithDefault(uri, &RepoCommentsURL, uriParams)
 	if err != nil {
 		return false, &Result{Err: err}
 	}

--- a/octokit/followers.go
+++ b/octokit/followers.go
@@ -19,12 +19,8 @@ type FollowersService struct {
 }
 
 // Get a list of followers for the user
-func (f *FollowersService) All(uri *Hyperlink, params M) (followers []User, result *Result) {
-	if uri == nil {
-		uri = &CurrentFollowerUrl // Default url
-	}
-
-	url, err := uri.Expand(params)
+func (f *FollowersService) All(uri *Hyperlink, uriParams M) (followers []User, result *Result) {
+	url, err := ExpandWithDefault(uri, &CurrentFollowerUrl, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
@@ -34,12 +30,8 @@ func (f *FollowersService) All(uri *Hyperlink, params M) (followers []User, resu
 }
 
 // Checks if a user is following a target user
-func (f *FollowersService) Check(uri *Hyperlink, params M) (success bool, result *Result) {
-	if uri == nil {
-		uri = &CurrentFollowingUrl // Default url
-	}
-
-	url, err := uri.Expand(params)
+func (f *FollowersService) Check(uri *Hyperlink, uriParams M) (success bool, result *Result) {
+	url, err := ExpandWithDefault(uri, &CurrentFollowingUrl, uriParams)
 	if err != nil {
 		return false, &Result{Err: err}
 	}
@@ -50,12 +42,8 @@ func (f *FollowersService) Check(uri *Hyperlink, params M) (success bool, result
 }
 
 // Follows a target user
-func (f *FollowersService) Follow(uri *Hyperlink, params M) (success bool, result *Result) {
-	if uri == nil {
-		uri = &CurrentFollowingUrl // Default url
-	}
-
-	url, err := uri.Expand(params)
+func (f *FollowersService) Follow(uri *Hyperlink, uriParams M) (success bool, result *Result) {
+	url, err := ExpandWithDefault(uri, &CurrentFollowingUrl, uriParams)
 	if err != nil {
 		return false, &Result{Err: err}
 	}
@@ -66,12 +54,8 @@ func (f *FollowersService) Follow(uri *Hyperlink, params M) (success bool, resul
 }
 
 // Unfollows a target user
-func (f *FollowersService) Unfollow(uri *Hyperlink, params M) (success bool, result *Result) {
-	if uri == nil {
-		uri = &CurrentFollowingUrl // Default url
-	}
-
-	url, err := uri.Expand(params)
+func (f *FollowersService) Unfollow(uri *Hyperlink, uriParams M) (success bool, result *Result) {
+	url, err := ExpandWithDefault(uri, &CurrentFollowingUrl, uriParams)
 	if err != nil {
 		return false, &Result{Err: err}
 	}

--- a/octokit/gist_comments.go
+++ b/octokit/gist_comments.go
@@ -20,12 +20,8 @@ type GistCommentsService struct {
 }
 
 // Get a list of all gist comments
-func (c *GistCommentsService) All(uri *Hyperlink, params M) (comments []GistComment, result *Result) {
-	if uri == nil {
-		uri = &GistCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *GistCommentsService) All(uri *Hyperlink, uriParams M) (comments []GistComment, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistCommentsURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
@@ -35,12 +31,8 @@ func (c *GistCommentsService) All(uri *Hyperlink, params M) (comments []GistComm
 }
 
 // Get a single comment by id
-func (c *GistCommentsService) One(uri *Hyperlink, params M) (comment *GistComment, result *Result) {
-	if uri == nil {
-		uri = &GistCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *GistCommentsService) One(uri *Hyperlink, uriParams M) (comment *GistComment, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistCommentsURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
@@ -50,42 +42,30 @@ func (c *GistCommentsService) One(uri *Hyperlink, params M) (comment *GistCommen
 }
 
 // Creates a comment on a gist
-func (c *GistCommentsService) Create(uri *Hyperlink, params M, input interface{}) (comment *GistComment, result *Result) {
-	if uri == nil {
-		uri = &GistCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *GistCommentsService) Create(uri *Hyperlink, uriParams M, requestParams interface{}) (comment *GistComment, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistCommentsURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
 
-	result = c.client.post(url, input, &comment)
+	result = c.client.post(url, requestParams, &comment)
 	return
 }
 
 // Updates a comment on a gist
-func (c *GistCommentsService) Update(uri *Hyperlink, params M, input interface{}) (comment *GistComment, result *Result) {
-	if uri == nil {
-		uri = &GistCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *GistCommentsService) Update(uri *Hyperlink, uriParams M, requestParams interface{}) (comment *GistComment, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistCommentsURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
 
-	result = c.client.patch(url, input, &comment)
+	result = c.client.patch(url, requestParams, &comment)
 	return
 }
 
 // Deletes a comment on a gist
-func (c *GistCommentsService) Delete(uri *Hyperlink, params M) (success bool, result *Result) {
-	if uri == nil {
-		uri = &GistCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *GistCommentsService) Delete(uri *Hyperlink, uriParams M) (success bool, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistCommentsURL, uriParams)
 	if err != nil {
 		return false, &Result{Err: err}
 	}

--- a/octokit/gists.go
+++ b/octokit/gists.go
@@ -45,14 +45,12 @@ type GistsService struct {
 // All gets a list of all gists associated with the url of the service
 //
 // https://developer.github.com/v3/gists/#list-gists
-func (g *GistsService) All(uri *Hyperlink, params M) (gists []Gist, result *Result) {
-	if uri == nil {
-		uri = &GistsURL
-	}
-	url, err := uri.Expand(params)
+func (g *GistsService) All(uri *Hyperlink, uriParams M) (gists []Gist, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistsURL, uriParams)
 	if err != nil {
-		return make([]Gist, 0), &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
+
 	result = g.client.get(url, &gists)
 	return
 }
@@ -61,14 +59,12 @@ func (g *GistsService) All(uri *Hyperlink, params M) (gists []Gist, result *Resu
 //
 // https://developer.github.com/v3/gists/#get-a-single-gist
 // https://developer.github.com/v3/gists/#get-a-specific-revision-of-a-gist
-func (g *GistsService) One(uri *Hyperlink, params M) (gist Gist, result *Result) {
-	if uri == nil {
-		uri = &GistsURL
-	}
-	url, err := uri.Expand(params)
+func (g *GistsService) One(uri *Hyperlink, uriParams M) (gist *Gist, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistsURL, uriParams)
 	if err != nil {
-		return Gist{}, &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
+
 	result = g.client.get(url, &gist)
 	return
 }
@@ -76,11 +72,10 @@ func (g *GistsService) One(uri *Hyperlink, params M) (gist Gist, result *Result)
 // Raw gets the raw contents of first file in a specific gist
 //
 // https://developer.github.com/v3/gists/#truncation
-func (g *GistsService) Raw(uri *Hyperlink, params M) (body io.ReadCloser, result *Result) {
-	var gist Gist
+func (g *GistsService) Raw(uri *Hyperlink, uriParams M) (body io.ReadCloser, result *Result) {
 	var rawURL *url.URL
 
-	gist, result = g.One(uri, params)
+	gist, result := g.One(uri, uriParams)
 	for _, file := range gist.Files {
 		rawURL, _ = url.Parse(file.RawURL)
 		break
@@ -94,44 +89,38 @@ func (g *GistsService) Raw(uri *Hyperlink, params M) (body io.ReadCloser, result
 // the specified URL
 //
 // https://developer.github.com/v3/gists/#create-a-gist
-func (g *GistsService) Create(uri *Hyperlink, params M, creating interface{}) (gist Gist, result *Result) {
-	if uri == nil {
-		uri = &GistsURL
-	}
-	url, err := uri.Expand(params)
+func (g *GistsService) Create(uri *Hyperlink, uriParams M, requestParams interface{}) (gist *Gist, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistsURL, uriParams)
 	if err != nil {
-		return Gist{}, &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
-	result = g.client.post(url, creating, &gist)
+
+	result = g.client.post(url, requestParams, &gist)
 	return
 }
 
 // Update modifies a specific gist based on the url of the service
 //
 // https://developer.github.com/v3/gists/#edit-a-gist
-func (g *GistsService) Update(uri *Hyperlink, params M, edits interface{}) (gist Gist, result *Result) {
-	if uri == nil {
-		uri = &GistsURL
-	}
-	url, err := uri.Expand(params)
+func (g *GistsService) Update(uri *Hyperlink, uriParams M, requestParams interface{}) (gist *Gist, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistsURL, uriParams)
 	if err != nil {
-		return Gist{}, &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
-	result = g.client.patch(url, edits, &gist)
+
+	result = g.client.patch(url, requestParams, &gist)
 	return
 }
 
 // Commits gets a list of all commits to the given gist
 //
 // https://developer.github.com/v3/gists/#list-gists
-func (g *GistsService) Commits(uri *Hyperlink, params M) (gistCommits []GistCommit, result *Result) {
-	if uri == nil {
-		uri = &GistsCommitsURL
-	}
-	url, err := uri.Expand(params)
+func (g *GistsService) Commits(uri *Hyperlink, uriParams M) (gistCommits []GistCommit, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistsCommitsURL, uriParams)
 	if err != nil {
-		return make([]GistCommit, 0), &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
+
 	result = g.client.get(url, &gistCommits)
 	return
 }
@@ -139,14 +128,12 @@ func (g *GistsService) Commits(uri *Hyperlink, params M) (gistCommits []GistComm
 // Star stars a gist
 //
 // https://developer.github.com/v3/gists/#star-a-gist
-func (g *GistsService) Star(uri *Hyperlink, params M) (success bool, result *Result) {
-	if uri == nil {
-		uri = &GistsStarURL // Default url
-	}
-	url, err := uri.Expand(params)
+func (g *GistsService) Star(uri *Hyperlink, uriParams M) (success bool, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistsStarURL, uriParams)
 	if err != nil {
 		return false, &Result{Err: err}
 	}
+
 	result = g.client.put(url, nil, nil)
 	success = (!result.HasError() && result.Response.StatusCode == 204)
 	return
@@ -155,14 +142,12 @@ func (g *GistsService) Star(uri *Hyperlink, params M) (success bool, result *Res
 // Unstar unstars a gist
 //
 // https://developer.github.com/v3/gists/#unstar-a-gist
-func (g *GistsService) Unstar(uri *Hyperlink, params M) (success bool, result *Result) {
-	if uri == nil {
-		uri = &GistsStarURL // Default url
-	}
-	url, err := uri.Expand(params)
+func (g *GistsService) Unstar(uri *Hyperlink, uriParams M) (success bool, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistsStarURL, uriParams)
 	if err != nil {
 		return false, &Result{Err: err}
 	}
+
 	result = g.client.delete(url, nil, nil)
 	success = (!result.HasError() && result.Response.StatusCode == 204)
 	return
@@ -171,14 +156,12 @@ func (g *GistsService) Unstar(uri *Hyperlink, params M) (success bool, result *R
 // CheckStar checks if a gist is starred
 //
 // https://developer.github.com/v3/gists/#check-if-a-gist-is-starred
-func (g *GistsService) CheckStar(uri *Hyperlink, params M) (success bool, result *Result) {
-	if uri == nil {
-		uri = &GistsStarURL // Default url
-	}
-	url, err := uri.Expand(params)
+func (g *GistsService) CheckStar(uri *Hyperlink, uriParams M) (success bool, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistsStarURL, uriParams)
 	if err != nil {
 		return false, &Result{Err: err}
 	}
+
 	result = g.client.get(url, nil)
 	success = (!result.HasError() && result.Response.StatusCode == 204)
 	return
@@ -187,14 +170,12 @@ func (g *GistsService) CheckStar(uri *Hyperlink, params M) (success bool, result
 // Fork forks a gist
 //
 // https://developer.github.com/v3/gists/#fork-a-gist
-func (g *GistsService) Fork(uri *Hyperlink, params M) (gist Gist, result *Result) {
-	if uri == nil {
-		uri = &GistsForksURL
-	}
-	url, err := uri.Expand(params)
+func (g *GistsService) Fork(uri *Hyperlink, uriParams M) (gist *Gist, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistsForksURL, uriParams)
 	if err != nil {
-		return Gist{}, &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
+
 	result = g.client.post(url, nil, &gist)
 	return
 }
@@ -202,14 +183,12 @@ func (g *GistsService) Fork(uri *Hyperlink, params M) (gist Gist, result *Result
 // ListForks lists all the forks of a gist
 //
 // https://developer.github.com/v3/gists/#list-gist-forks
-func (g *GistsService) ListForks(uri *Hyperlink, params M) (gistForks []GistFork, result *Result) {
-	if uri == nil {
-		uri = &GistsForksURL
-	}
-	url, err := uri.Expand(params)
+func (g *GistsService) ListForks(uri *Hyperlink, uriParams M) (gistForks []GistFork, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistsForksURL, uriParams)
 	if err != nil {
-		return make([]GistFork, 0), &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
+
 	result = g.client.get(url, &gistForks)
 	return
 }
@@ -217,14 +196,12 @@ func (g *GistsService) ListForks(uri *Hyperlink, params M) (gistForks []GistFork
 // Delete deletes a gist by its id
 //
 // https://developer.github.com/v3/gists/#delete-a-gist
-func (g *GistsService) Delete(uri *Hyperlink, params M) (success bool, result *Result) {
-	if uri == nil {
-		uri = &GistsURL // Default url
-	}
-	url, err := uri.Expand(params)
+func (g *GistsService) Delete(uri *Hyperlink, uriParams M) (success bool, result *Result) {
+	url, err := ExpandWithDefault(uri, &GistsURL, uriParams)
 	if err != nil {
 		return false, &Result{Err: err}
 	}
+
 	result = g.client.delete(url, nil, nil)
 	success = (!result.HasError() && result.Response.StatusCode == 204)
 	return

--- a/octokit/gists_test.go
+++ b/octokit/gists_test.go
@@ -37,7 +37,7 @@ func TestGistsService_One(t *testing.T) {
 	var invalid = Hyperlink("{")
 	gistErr, resultErr := client.Gists().One(&invalid, M{})
 	assert.True(t, resultErr.HasError())
-	assert.Equal(t, gistErr, Gist{})
+	assert.Nil(t, gistErr)
 }
 
 func TestGistsService_Raw(t *testing.T) {
@@ -96,7 +96,7 @@ func TestGistsService_All(t *testing.T) {
 	var invalid = Hyperlink("{")
 	gistsErr, resultErr := client.Gists().All(&invalid, M{})
 	assert.True(t, resultErr.HasError())
-	assert.Equal(t, gistsErr, make([]Gist, 0))
+	assert.Len(t, gistsErr, 0)
 }
 
 func TestGistsService_Create(t *testing.T) {
@@ -144,7 +144,7 @@ func TestGistsService_Create(t *testing.T) {
 	var invalid = Hyperlink("{")
 	gistErr, resultErr := client.Gists().Create(&invalid, M{}, params)
 	assert.True(t, resultErr.HasError())
-	assert.Equal(t, gistErr, Gist{})
+	assert.Nil(t, gistErr)
 }
 
 func TestGistsService_Update(t *testing.T) {
@@ -201,7 +201,7 @@ func TestGistsService_Update(t *testing.T) {
 	var invalid = Hyperlink("{")
 	gistErr, resultErr := client.Gists().Update(&invalid, M{}, params)
 	assert.True(t, resultErr.HasError())
-	assert.Equal(t, gistErr, Gist{})
+	assert.Nil(t, gistErr)
 }
 
 func TestGistsService_Commits(t *testing.T) {
@@ -228,7 +228,7 @@ func TestGistsService_Commits(t *testing.T) {
 	var invalid = Hyperlink("{")
 	commitsErr, resultErr := client.Gists().Commits(&invalid, M{})
 	assert.True(t, resultErr.HasError())
-	assert.Equal(t, commitsErr, make([]GistCommit, 0))
+	assert.Len(t, commitsErr, 0)
 }
 
 func TestGistsService_Star(t *testing.T) {
@@ -354,7 +354,7 @@ func TestGistsService_Fork(t *testing.T) {
 	var invalid = Hyperlink("{")
 	gistErr, resultErr := client.Gists().Fork(&invalid, M{})
 	assert.True(t, resultErr.HasError())
-	assert.Equal(t, gistErr, Gist{})
+	assert.Nil(t, gistErr)
 }
 
 func TestGistsService_ListForks(t *testing.T) {
@@ -380,7 +380,7 @@ func TestGistsService_ListForks(t *testing.T) {
 	var invalid = Hyperlink("{")
 	forksErr, resultErr := client.Gists().ListForks(&invalid, M{})
 	assert.True(t, resultErr.HasError())
-	assert.Equal(t, forksErr, make([]GistFork, 0))
+	assert.Len(t, forksErr, 0)
 }
 
 func TestGistsService_Delete(t *testing.T) {

--- a/octokit/git_ignore.go
+++ b/octokit/git_ignore.go
@@ -16,26 +16,22 @@ type GitIgnoreService struct {
 
 // All gets a list all the available templates
 func (s *GitIgnoreService) All(uri *Hyperlink) (templates []string, result *Result) {
-	if uri == nil {
-		uri = &GitIgnoreURL
-	}
-	url, err := uri.Expand(nil)
+	url, err := ExpandWithDefault(uri, &GitIgnoreURL, nil)
 	if err != nil {
-		return make([]string, 0), &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
+
 	result = s.client.get(url, &templates)
 	return
 }
 
 // One gets a specific gitignore template based on the passed url
-func (s *GitIgnoreService) One(uri *Hyperlink, params M) (template GitIgnoreTemplate, result *Result) {
-	if uri == nil {
-		uri = &GitIgnoreURL
-	}
-	url, err := uri.Expand(params)
+func (s *GitIgnoreService) One(uri *Hyperlink, uriParams M) (template *GitIgnoreTemplate, result *Result) {
+	url, err := ExpandWithDefault(uri, &GitIgnoreURL, uriParams)
 	if err != nil {
-		return GitIgnoreTemplate{}, &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
+
 	result = s.client.get(url, &template)
 	return
 }

--- a/octokit/issue_comments.go
+++ b/octokit/issue_comments.go
@@ -20,12 +20,8 @@ type IssueCommentsService struct {
 }
 
 // Get a list of all issue comments
-func (c *IssueCommentsService) All(uri *Hyperlink, params M) (comments []IssueComment, result *Result) {
-	if uri == nil {
-		uri = &IssueCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *IssueCommentsService) All(uri *Hyperlink, uriParams M) (comments []IssueComment, result *Result) {
+	url, err := ExpandWithDefault(uri, &IssueCommentsURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
@@ -35,12 +31,8 @@ func (c *IssueCommentsService) All(uri *Hyperlink, params M) (comments []IssueCo
 }
 
 // Get a single comment by id
-func (c *IssueCommentsService) One(uri *Hyperlink, params M) (comment *IssueComment, result *Result) {
-	if uri == nil {
-		uri = &IssueCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *IssueCommentsService) One(uri *Hyperlink, uriParams M) (comment *IssueComment, result *Result) {
+	url, err := ExpandWithDefault(uri, &IssueCommentsURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
@@ -50,42 +42,30 @@ func (c *IssueCommentsService) One(uri *Hyperlink, params M) (comment *IssueComm
 }
 
 // Creates a comment on an issue
-func (c *IssueCommentsService) Create(uri *Hyperlink, params M, input interface{}) (comment *IssueComment, result *Result) {
-	if uri == nil {
-		uri = &IssueCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *IssueCommentsService) Create(uri *Hyperlink, uriParams M, requestParams interface{}) (comment *IssueComment, result *Result) {
+	url, err := ExpandWithDefault(uri, &IssueCommentsURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
 
-	result = c.client.post(url, input, &comment)
+	result = c.client.post(url, requestParams, &comment)
 	return
 }
 
 // Updates a comment on an issue
-func (c *IssueCommentsService) Update(uri *Hyperlink, params M, input interface{}) (comment *IssueComment, result *Result) {
-	if uri == nil {
-		uri = &IssueCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *IssueCommentsService) Update(uri *Hyperlink, uriParams M, requestParams interface{}) (comment *IssueComment, result *Result) {
+	url, err := ExpandWithDefault(uri, &IssueCommentsURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
 
-	result = c.client.patch(url, input, &comment)
+	result = c.client.patch(url, requestParams, &comment)
 	return
 }
 
 // Deletes a comment on an issue
-func (c *IssueCommentsService) Delete(uri *Hyperlink, params M) (success bool, result *Result) {
-	if uri == nil {
-		uri = &IssueCommentsURL
-	}
-
-	url, err := uri.Expand(params)
+func (c *IssueCommentsService) Delete(uri *Hyperlink, uriParams M) (success bool, result *Result) {
+	url, err := ExpandWithDefault(uri, &IssueCommentsURL, uriParams)
 	if err != nil {
 		return false, &Result{Err: err}
 	}

--- a/octokit/issues.go
+++ b/octokit/issues.go
@@ -21,58 +21,46 @@ type IssuesService struct {
 }
 
 // One gets a specific issue based on the url of the service
-func (i *IssuesService) One(uri *Hyperlink, params M) (issue *Issue,
-	result *Result) {
-	if uri == nil {
-		uri = &RepoIssuesURL
-	}
-	url, err := uri.Expand(params)
+func (i *IssuesService) One(uri *Hyperlink, uriParams M) (issue *Issue, result *Result) {
+	url, err := ExpandWithDefault(uri, &RepoIssuesURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
+
 	result = i.client.get(url, &issue)
 	return
 }
 
 // All gets a list of all issues associated with the url of the service
-func (i *IssuesService) All(uri *Hyperlink, uriParams M) (issues []Issue,
-	result *Result) {
-	if uri == nil {
-		uri = &RepoIssuesURL
-	}
-	url, err := uri.Expand(uriParams)
+func (i *IssuesService) All(uri *Hyperlink, uriParams M) (issues []Issue, result *Result) {
+	url, err := ExpandWithDefault(uri, &RepoIssuesURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
+
 	result = i.client.get(url, &issues)
 	return
 }
 
 // Create posts a new issue with particular parameters to the issues service url
-func (i *IssuesService) Create(uri *Hyperlink, uriParams M,
-	params interface{}) (issue *Issue, result *Result) {
-	if uri == nil {
-		uri = &RepoIssuesURL
-	}
-	url, err := uri.Expand(uriParams)
+func (i *IssuesService) Create(uri *Hyperlink, uriParams M, requestParams interface{}) (issue *Issue, result *Result) {
+	url, err := ExpandWithDefault(uri, &RepoIssuesURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
-	result = i.client.post(url, params, &issue)
+
+	result = i.client.post(url, requestParams, &issue)
 	return
 }
 
 // Update modifies a specific issue given parameters on the service url
-func (i *IssuesService) Update(uri *Hyperlink, uriParams M,
-	params interface{}) (issue *Issue, result *Result) {
-	if uri == nil {
-		uri = &RepoIssuesURL
-	}
-	url, err := uri.Expand(uriParams)
+func (i *IssuesService) Update(uri *Hyperlink, uriParams M, requestParams interface{}) (issue *Issue, result *Result) {
+	url, err := ExpandWithDefault(uri, &RepoIssuesURL, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
-	result = i.client.patch(url, params, &issue)
+
+	result = i.client.patch(url, requestParams, &issue)
 	return
 }
 

--- a/octokit/public_keys.go
+++ b/octokit/public_keys.go
@@ -23,8 +23,8 @@ type PublicKeysService struct {
 }
 
 // Get a list of keys for the user
-func (k *PublicKeysService) All(uri *Hyperlink, params M) (keys []Key, result *Result) {
-	url, err := ExpandWithDefault(uri, &CurrentPublicKeyUrl, params)
+func (k *PublicKeysService) All(uri *Hyperlink, uriParams M) (keys []Key, result *Result) {
+	url, err := ExpandWithDefault(uri, &CurrentPublicKeyUrl, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
@@ -34,8 +34,8 @@ func (k *PublicKeysService) All(uri *Hyperlink, params M) (keys []Key, result *R
 }
 
 // Get a the data for one key for the current user
-func (k *PublicKeysService) One(uri *Hyperlink, params M) (key *Key, result *Result) {
-	url, err := ExpandWithDefault(uri, &CurrentPublicKeyUrl, params)
+func (k *PublicKeysService) One(uri *Hyperlink, uriParams M) (key *Key, result *Result) {
+	url, err := ExpandWithDefault(uri, &CurrentPublicKeyUrl, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
@@ -45,19 +45,19 @@ func (k *PublicKeysService) One(uri *Hyperlink, params M) (key *Key, result *Res
 }
 
 // Creates a new public key for the current user
-func (k *PublicKeysService) Create(uri *Hyperlink, uriParams M, inputParams interface{}) (key *Key, result *Result) {
+func (k *PublicKeysService) Create(uri *Hyperlink, uriParams M, requestParams interface{}) (key *Key, result *Result) {
 	url, err := ExpandWithDefault(uri, &CurrentPublicKeyUrl, uriParams)
 	if err != nil {
 		return nil, &Result{Err: err}
 	}
 
-	result = k.client.post(url, inputParams, &key)
+	result = k.client.post(url, requestParams, &key)
 	return
 }
 
 // Removes a public key for the current user
-func (k *PublicKeysService) Delete(uri *Hyperlink, params M) (success bool, result *Result) {
-	url, err := ExpandWithDefault(uri, &CurrentPublicKeyUrl, params)
+func (k *PublicKeysService) Delete(uri *Hyperlink, uriParams M) (success bool, result *Result) {
+	url, err := ExpandWithDefault(uri, &CurrentPublicKeyUrl, uriParams)
 	if err != nil {
 		return false, &Result{Err: err}
 	}

--- a/octokit/search.go
+++ b/octokit/search.go
@@ -21,57 +21,45 @@ type SearchService struct {
 }
 
 // Get the user search results based on SearchService#URL
-func (g *SearchService) Users(uri *Hyperlink, params M) (
-	userSearchResults UserSearchResults, result *Result) {
-	if uri == nil {
-		uri = &UserSearchURL
-	}
-	url, err := uri.Expand(params)
+func (g *SearchService) Users(uri *Hyperlink, uriParams M) (userSearchResults *UserSearchResults, result *Result) {
+	url, err := ExpandWithDefault(uri, &UserSearchURL, uriParams)
 	if err != nil {
-		return UserSearchResults{}, &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
+
 	result = g.client.get(url, &userSearchResults)
 	return
 }
 
 // Get the issue search results based on SearchService#URL
-func (g *SearchService) Issues(uri *Hyperlink, params M) (
-	issueSearchResults IssueSearchResults, result *Result) {
-	if uri == nil {
-		uri = &IssueSearchURL
-	}
-	url, err := uri.Expand(params)
+func (g *SearchService) Issues(uri *Hyperlink, uriParams M) (issueSearchResults *IssueSearchResults, result *Result) {
+	url, err := ExpandWithDefault(uri, &IssueSearchURL, uriParams)
 	if err != nil {
-		return IssueSearchResults{}, &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
+
 	result = g.client.get(url, &issueSearchResults)
 	return
 }
 
 // Get the repository search results based on SearchService#URL
-func (g *SearchService) Repositories(uri *Hyperlink, params M) (
-	repositorySearchResults RepositorySearchResults, result *Result) {
-	if uri == nil {
-		uri = &RepositorySearchURL
-	}
-	url, err := uri.Expand(params)
+func (g *SearchService) Repositories(uri *Hyperlink, uriParams M) (repositorySearchResults *RepositorySearchResults, result *Result) {
+	url, err := ExpandWithDefault(uri, &RepositorySearchURL, uriParams)
 	if err != nil {
-		return RepositorySearchResults{}, &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
+
 	result = g.client.get(url, &repositorySearchResults)
 	return
 }
 
 // Get the code search results based on SearchService#URL
-func (g *SearchService) Code(uri *Hyperlink, params M) (
-	codeSearchResults CodeSearchResults, result *Result) {
-	if uri == nil {
-		uri = &CodeSearchURL
-	}
-	url, err := uri.Expand(params)
+func (g *SearchService) Code(uri *Hyperlink, uriParams M) (codeSearchResults *CodeSearchResults, result *Result) {
+	url, err := ExpandWithDefault(uri, &CodeSearchURL, uriParams)
 	if err != nil {
-		return CodeSearchResults{}, &Result{Err: err}
+		return nil, &Result{Err: err}
 	}
+
 	result = g.client.get(url, &codeSearchResults)
 	return
 }


### PR DESCRIPTION
* Default uri expansion all use `ExpandWithDefault` now. 
* In order to keep everything consistent, parameters for uri expansion are named `uriParams` while parameters sent with the request are named `requestParams`.
* Return type changed to pointers to be consistent with the rest of go-octokit.
* Failure cases changed to default to `nil` rather than returning an empty struct or an empty slice.