### PR TITLE
[WIP] Add markdown API

### DIFF
--- a/fixtures/markdown.html
+++ b/fixtures/markdown.html
@@ -1,0 +1,5 @@
+<p>Hello world 
+    <a href="https://github.com/github/linguist/issues/1" class="issue-link" title="Binary detection issues on extensionless files">github/linguist#1</a>
+    <strong>cool</strong>, and 
+    <a href="https://github.com/gollum/gollum/issues/1" class="issue-link" title="no method to write a file?">#1</a>!
+</p>

--- a/fixtures/markdown_raw.html
+++ b/fixtures/markdown_raw.html
@@ -1,0 +1,3 @@
+<p>Hello world github/linguist#1 
+    <strong>cool</strong>, and #1!
+</p>

--- a/octokit/markdown.go
+++ b/octokit/markdown.go
@@ -1,0 +1,43 @@
+package octokit
+
+import (
+	"io/ioutil"
+)
+
+// MardownURL is for rendering an arbitrary markdown document
+// MarkdownRawURL is for rendering raw markdown
+var (
+	MarkdownURL    = Hyperlink("/markdown")
+	MarkdownRawURL = Hyperlink("/markdown/raw")
+)
+
+// Create a MarkdownService
+func (c *Client) Markdown() (m *MarkdownService) {
+	m = &MarkdownService{client: c}
+	return
+}
+
+// A service to return HTML rendered markdown document
+type MarkdownService struct {
+	client *Client
+}
+
+// Renders a markdown document
+func (m *MarkdownService) Render(uri *Hyperlink, requestParams interface{}) (renderedHTML string, result *Result) {
+	url, err := ExpandWithDefault(uri, &MarkdownURL, nil)
+	if err != nil {
+		return "", &Result{Err: err}
+	}
+
+	result = sendRequest(m.client, url, func(req *Request) (*Response, error) {
+		req.setBody(requestParams)
+		return req.createResponseRaw(req.Request.Post())
+	})
+
+	body, err := ioutil.ReadAll(result.Response.Body)
+	if err != nil {
+		return "", &Result{Err: err}
+	}
+	renderedHTML = string(body)
+	return
+}

--- a/octokit/markdown_test.go
+++ b/octokit/markdown_test.go
@@ -1,0 +1,68 @@
+package octokit
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarkdownService_JSON(t *testing.T) {
+	setup()
+	defer tearDown()
+
+	mux.HandleFunc("/markdown", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testBody(t, r, "{\"context\":\"github/gollum\",\"mode\":\"gfm\",\"text\":\"Hello world github/linguist#1 **cool**, and #1!\"}\n")
+
+		respondWith(w, loadFixture("markdown.html"))
+	})
+
+	input := M{
+		"text":    "Hello world github/linguist#1 **cool**, and #1!",
+		"mode":    "gfm",
+		"context": "github/gollum",
+	}
+
+	markdown, result := client.Markdown().Render(nil, input)
+	assert.False(t, result.HasError())
+
+	expected := "<p>Hello world \r\n" +
+		"    <a href=\"https://github.com/github/linguist/issues/1\" class=\"issue-link\" title=\"Binary detection issues on extensionless files\">github/linguist#1</a>\r\n" +
+		"    <strong>cool</strong>, and \r\n" +
+		"    <a href=\"https://github.com/gollum/gollum/issues/1\" class=\"issue-link\" title=\"no method to write a file?\">#1</a>!\r\n" +
+		"</p>"
+	assert.Equal(t, expected, markdown)
+}
+
+func TestMarkdownService_RAW(t *testing.T) {
+	setup()
+	defer tearDown()
+
+	mux.HandleFunc("/markdown/raw", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testBody(t, r, "\"Hello world github/linguist#1 **cool**, and #1!\"\n")
+
+		respondWith(w, loadFixture("markdown_raw.html"))
+	})
+
+	input := "Hello world github/linguist#1 **cool**, and #1!"
+
+	markdown, result := client.Markdown().Render(&MarkdownRawURL, input)
+	assert.False(t, result.HasError())
+
+	expected := "<p>Hello world github/linguist#1 \r\n" +
+		"    <strong>cool</strong>, and #1!\r\n" +
+		"</p>"
+	assert.Equal(t, expected, markdown)
+}
+
+func TestMarkdownService_Failure(t *testing.T) {
+	setup()
+	defer tearDown()
+
+	url := Hyperlink("}")
+	markdown, result := client.Markdown().Render(&url, nil)
+	assert.True(t, result.HasError())
+	assert.Empty(t, markdown)
+}

--- a/octokit/request.go
+++ b/octokit/request.go
@@ -74,6 +74,11 @@ func (r *Request) setBody(input interface{}) {
 	r.Request.SetBody(mtype, input)
 }
 
+func (r *Request) createResponseRaw(sawyerResp *sawyer.Response) (resp *Response, err error) {
+	resp, err = NewResponse(sawyerResp)
+	return
+}
+
 func (r *Request) createResponse(sawyerResp *sawyer.Response, output interface{}) (resp *Response, err error) {
 	resp, err = NewResponse(sawyerResp)
 	if err == nil {


### PR DESCRIPTION
Added functionality for https://developer.github.com/v3/markdown/

@pengwynn It seems like the markdown API is one of the few (only?) API endpoints that return html rather than json. However, there is no support for encoding and decoding `text/html;charset=utf-8`. This is due to the fact that go-sawyer was only initialized with an encoder and decoder for json: https://github.com/jingweno/go-sawyer/blob/master/sawyer.go#L82-L89

At the moment, the workaround I implemented is kind of hacky: I get the raw response back from the server and then directly parse it into a string. 

Additionally, encoding a string with `setBody` defaults to using json encoding as well. This results in strings getting encoded with two extra quotation marks:
`testBody(t, r, "\"Hello world github/linguist#1 **cool**, and #1!\"\n")`
should be
`testBody(t, r, "Hello world github/linguist#1 **cool**, and #1!\n")`

What are your thoughts about this?