### PR TITLE
Finished updating all tests to use stub

### DIFF
--- a/octokit/authorizations_test.go
+++ b/octokit/authorizations_test.go
@@ -2,7 +2,6 @@ package octokit
 
 import (
 	"encoding/json"
-	"net/http"
 	"reflect"
 	"testing"
 
@@ -72,14 +71,8 @@ func TestAuthorizationsService_Create(t *testing.T) {
 
 	params := AuthorizationParams{Scopes: []string{"public_repo"}}
 
-	mux.HandleFunc("/authorizations", func(w http.ResponseWriter, r *http.Request) {
-		var authParams AuthorizationParams
-		json.NewDecoder(r.Body).Decode(&authParams)
-		assert.True(t, reflect.DeepEqual(authParams, params))
-
-		testMethod(t, r, "POST")
-		respondWithJSON(w, loadFixture("create_authorization.json"))
-	})
+	wantReqBody, _ := json.Marshal(params)
+	stubPost(t, "/authorizations", "create_authorization", nil, string(wantReqBody)+"\n", nil)
 
 	url, err := AuthorizationsURL.Expand(nil)
 	assert.NoError(t, err)

--- a/octokit/followers_test.go
+++ b/octokit/followers_test.go
@@ -84,14 +84,8 @@ func TestFollowersService_CheckFollowing(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/users/harrisonzhao/following/obsc", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-
-		header := w.Header()
-		header.Set("Content-Type", "application/json")
-
-		respondWithStatus(w, 204)
-	})
+	respHeaderParams := map[string]string{"Content-Type": "application/json"}
+	stubGetwCode(t, "/users/harrisonzhao/following/obsc", "", respHeaderParams, 204)
 
 	success, result := client.Followers().Check(&FollowingUrl, M{"user": "harrisonzhao", "target": "obsc"})
 	assert.False(t, result.HasError())

--- a/octokit/followers_test.go
+++ b/octokit/followers_test.go
@@ -2,7 +2,6 @@ package octokit
 
 import (
 	"fmt"
-	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,14 +95,8 @@ func TestFollowersService_CheckCurrentFollowing(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/user/following/obsc", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-
-		header := w.Header()
-		header.Set("Content-Type", "application/json")
-
-		respondWithStatus(w, 204)
-	})
+	respHeaderParams := map[string]string{"Content-Type": "application/json"}
+	stubGetwCode(t, "/user/following/obsc", "", respHeaderParams, 204)
 
 	success, result := client.Followers().Check(nil, M{"target": "obsc"})
 	assert.False(t, result.HasError())
@@ -114,14 +107,8 @@ func TestFollowersService_FollowUser(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/user/following/obsc", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-
-		header := w.Header()
-		header.Set("Content-Type", "application/json")
-
-		respondWithStatus(w, 204)
-	})
+	respHeaderParams := map[string]string{"Content-Type": "application/json"}
+	stubPutwCode(t, "/user/following/obsc", "", nil, "", respHeaderParams, 204)
 
 	success, result := client.Followers().Follow(nil, M{"target": "obsc"})
 	assert.False(t, result.HasError())
@@ -133,14 +120,8 @@ func TestFollowersService_UnfollowUser(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/user/following/obsc", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-
-		header := w.Header()
-		header.Set("Content-Type", "application/json")
-
-		respondWithStatus(w, 204)
-	})
+	respHeaderParams := map[string]string{"Content-Type": "application/json"}
+	stubDeletewCode(t, "/user/following/obsc", respHeaderParams, 204)
 
 	success, result := client.Followers().Unfollow(nil, M{"target": "obsc"})
 	assert.False(t, result.HasError())

--- a/octokit/gist_comments_test.go
+++ b/octokit/gist_comments_test.go
@@ -1,8 +1,8 @@
 package octokit
 
 import (
+	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
@@ -46,14 +46,9 @@ func TestGistCommentsService_CreateComment(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/gists/1721489/comments", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		testBody(t, r, "{\"body\":\"I am a comment\"}\n")
-
-		respondWithJSON(w, loadFixture("gist_comment.json"))
-	})
-
 	input := M{"body": "I am a comment"}
+	wantReqBody, _ := json.Marshal(input)
+	stubPost(t, "/gists/1721489/comments", "gist_comment", nil, string(wantReqBody)+"\n", nil)
 
 	comment, result := client.GistComments().Create(nil, M{"gist_id": 1721489}, input)
 	assert.False(t, result.HasError())
@@ -65,14 +60,9 @@ func TestGistCommentsService_UpdateComment(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/gists/1721489/comments/1199157", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PATCH")
-		testBody(t, r, "{\"body\":\"I am a comment\"}\n")
-
-		respondWithJSON(w, loadFixture("gist_comment.json"))
-	})
-
 	input := M{"body": "I am a comment"}
+	wantReqBody, _ := json.Marshal(input)
+	stubPatch(t, "/gists/1721489/comments/1199157", "gist_comment", nil, string(wantReqBody)+"\n", nil)
 
 	comment, result := client.GistComments().Update(nil, M{"gist_id": 1721489, "id": 1199157}, input)
 	assert.False(t, result.HasError())
@@ -84,13 +74,8 @@ func TestGistCommentsService_DeleteComment(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/gists/1721489/comments/1199157", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		header := w.Header()
-		header.Set("Content-Type", "application/json")
-
-		respondWithStatus(w, 204)
-	})
+	respHeaderParams := map[string]string{"Content-Type": "application/json"}
+	stubDeletewCode(t, "/gists/1721489/comments/1199157", respHeaderParams, 204)
 
 	success, result := client.GistComments().Delete(nil, M{"gist_id": 1721489, "id": 1199157})
 	assert.False(t, result.HasError())

--- a/octokit/gists_test.go
+++ b/octokit/gists_test.go
@@ -209,7 +209,7 @@ func TestGistsService_Star(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	var respHeaderParams = map[string]string{"Content-Type": "application/json"}
+	respHeaderParams := map[string]string{"Content-Type": "application/json"}
 	stubPutwCode(t, "/gists/aa5a315d61ae9438b18d/star", "gist", nil, "", respHeaderParams, 204)
 
 	success, result := client.Gists().Star(&GistsStarURL, M{"gist_id": "aa5a315d61ae9438b18d"})
@@ -231,7 +231,7 @@ func TestGistsService_Unstar(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	var respHeaderParams = map[string]string{"Content-Type": "application/json"}
+	respHeaderParams := map[string]string{"Content-Type": "application/json"}
 	stubDeletewCode(t, "/gists/aa5a315d61ae9438b18d/star", respHeaderParams, 204)
 
 	success, result := client.Gists().Unstar(&GistsStarURL, M{"gist_id": "aa5a315d61ae9438b18d"})

--- a/octokit/gists_test.go
+++ b/octokit/gists_test.go
@@ -341,7 +341,7 @@ func TestGistsService_Delete(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	var respHeaderParams = map[string]string{"Content-Type": "application/json"}
+	respHeaderParams := map[string]string{"Content-Type": "application/json"}
 	stubDeletewCode(t, "/gists/aa5a315d61ae9438b18d", respHeaderParams, 204)
 
 	success, result := client.Gists().Delete(&GistsURL, M{"gist_id": "aa5a315d61ae9438b18d"})

--- a/octokit/issue_comments_test.go
+++ b/octokit/issue_comments_test.go
@@ -1,8 +1,8 @@
 package octokit
 
 import (
+	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
@@ -65,14 +65,9 @@ func TestIssueCommentsService_CreateComment(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/octokit/go-octokit/issues/1/comments", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		testBody(t, r, "{\"body\":\"I am a comment\"}\n")
-
-		respondWithJSON(w, loadFixture("issue_comment.json"))
-	})
-
 	input := M{"body": "I am a comment"}
+	wantReqBody, _ := json.Marshal(input)
+	stubPost(t, "/repos/octokit/go-octokit/issues/1/comments", "issue_comment", nil, string(wantReqBody)+"\n", nil)
 
 	comment, result := client.IssueComments().Create(nil, M{"owner": "octokit", "repo": "go-octokit", "number": 1}, input)
 	assert.False(t, result.HasError())
@@ -84,14 +79,9 @@ func TestIssueCommentsService_UpdateComment(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/octokit/go-octokit/issues/comments/19158753", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PATCH")
-		testBody(t, r, "{\"body\":\"I am a comment\"}\n")
-
-		respondWithJSON(w, loadFixture("issue_comment.json"))
-	})
-
 	input := M{"body": "I am a comment"}
+	wantReqBody, _ := json.Marshal(input)
+	stubPatch(t, "/repos/octokit/go-octokit/issues/comments/19158753", "issue_comment", nil, string(wantReqBody)+"\n", nil)
 
 	comment, result := client.IssueComments().Update(nil, M{"owner": "octokit", "repo": "go-octokit", "id": 19158753}, input)
 	assert.False(t, result.HasError())
@@ -103,13 +93,8 @@ func TestIssueCommentsService_DeleteComment(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/octokit/go-octokit/issues/comments/19158753", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
-		header := w.Header()
-		header.Set("Content-Type", "application/json")
-
-		respondWithStatus(w, 204)
-	})
+	var respHeaderParams = map[string]string{"Content-Type": "application/json"}
+	stubDeletewCode(t, "/repos/octokit/go-octokit/issues/comments/19158753", respHeaderParams, 204)
 
 	success, result := client.IssueComments().Delete(nil, M{"owner": "octokit", "repo": "go-octokit", "id": 19158753})
 	assert.False(t, result.HasError())

--- a/octokit/issues_test.go
+++ b/octokit/issues_test.go
@@ -1,7 +1,7 @@
 package octokit
 
 import (
-	"net/http"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -40,17 +40,13 @@ func TestIssuesService_Create(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/octocat/Hello-World/issues", func(
-		w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		testBody(t, r, "{\"title\":\"title\",\"body\":\"body\"}\n")
-		respondWithJSON(w, loadFixture("issue.json"))
-	})
-
 	params := IssueParams{
 		Title: "title",
 		Body:  "body",
 	}
+	wantReqBody, _ := json.Marshal(params)
+	stubPost(t, "/repos/octocat/Hello-World/issues", "issue", nil, string(wantReqBody)+"\n", nil)
+
 	issue, result := client.Issues().Create(nil, M{"owner": "octocat",
 		"repo": "Hello-World"}, params)
 
@@ -62,17 +58,13 @@ func TestIssuesService_Update(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/octocat/Hello-World/issues/1347", func(
-		w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PATCH")
-		testBody(t, r, "{\"title\":\"title\",\"body\":\"body\"}\n")
-		respondWithJSON(w, loadFixture("issue.json"))
-	})
-
 	params := IssueParams{
 		Title: "title",
 		Body:  "body",
 	}
+	wantReqBody, _ := json.Marshal(params)
+	stubPatch(t, "/repos/octocat/Hello-World/issues/1347", "issue", nil, string(wantReqBody)+"\n", nil)
+
 	issue, result := client.Issues().Update(nil, M{"owner": "octocat",
 		"repo": "Hello-World", "number": 1347}, params)
 

--- a/octokit/octokit_test.go
+++ b/octokit/octokit_test.go
@@ -168,6 +168,12 @@ func stubDeletewCode(t *testing.T, path string,
 		nil, "", respHeaderParams, respStatusCode)
 }
 
+func stubDeletewCodewBody(t *testing.T, path string, wantReqBody string,
+	respHeaderParams map[string]string, respStatusCode int) {
+	httpTestHelper(t, path, "", "DELETE",
+		nil, wantReqBody, respHeaderParams, respStatusCode)
+}
+
 func httpTestHelper(t *testing.T, path string, fixture string,
 	wantReqMethod string, wantReqHeader map[string]string, wantReqBody string,
 	respHeaderParams map[string]string, respStatusCode int) {

--- a/octokit/octokit_test.go
+++ b/octokit/octokit_test.go
@@ -128,17 +128,6 @@ func stubGet(t *testing.T, path string, fixture string,
 	httpTestHelper(t, path, fixture, "GET", nil, "", respHeaderParams, 0)
 }
 
-func stubGetWithStatusCode(t *testing.T, path string, statusCode int) {
-	if mux == nil {
-		panic(fmt.Errorf("test HTTP server has not been set up"))
-	}
-
-	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-		respondWithStatus(w, statusCode)
-	})
-}
-
 func stubGetwCode(t *testing.T, path string, fixture string,
 	respHeaderParams map[string]string, respStatusCode int) {
 	httpTestHelper(t, path, fixture, "GET",

--- a/octokit/organizations_test.go
+++ b/octokit/organizations_test.go
@@ -3,8 +3,7 @@ package octokit
 import (
 	"github.com/stretchr/testify/assert"
 
-	"fmt"
-	"net/http"
+	"encoding/json"
 	"testing"
 )
 
@@ -25,21 +24,6 @@ func TestOrganizationService_Update(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	wantBodyParams := fmt.Sprintf(`{"%s":"%s","%s":"%s","%s":"%s","%s":"%s","%s":"%s","%s":"%s","%s":"%s"}`+"\n",
-		"billing_email", "support@github.com",
-		"blog", "https://github.com/blog",
-		"company", "GitHub",
-		"email", "support@github.com",
-		"location", "San Francisco",
-		"name", "github",
-		"description", "GitHub, the company.")
-
-	mux.HandleFunc("/orgs/github", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PATCH")
-		testBody(t, r, wantBodyParams)
-		respondWithJSON(w, loadFixture("organization_updated.json"))
-	})
-
 	input := OrganizationParams{
 		BillingEmail: "support@github.com",
 		Blog:         "https://github.com/blog",
@@ -49,6 +33,9 @@ func TestOrganizationService_Update(t *testing.T) {
 		Name:         "github",
 		Description:  "GitHub, the company.",
 	}
+	wantReqBody, _ := json.Marshal(input)
+	stubPatch(t, "/orgs/github", "organization_updated", nil, string(wantReqBody)+"\n", nil)
+
 	organizationResults, result := client.Organization().OrganizationUpdate(nil, input, M{"org": "github"})
 
 	assert.False(t, result.HasError())

--- a/octokit/pull_requests_test.go
+++ b/octokit/pull_requests_test.go
@@ -1,6 +1,7 @@
 package octokit
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -58,13 +59,6 @@ func TestPullRequestService_Post(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/octokit/go-octokit/pulls", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		testBody(t, r,
-			"{\"base\":\"base\",\"head\":\"head\",\"title\":\"title\",\"body\":\"body\",\"assignee\":\"assignee\"}\n")
-		respondWithJSON(w, loadFixture("pull_request.json"))
-	})
-
 	url, err := PullRequestsURL.Expand(M{"owner": "octokit", "repo": "go-octokit"})
 	assert.NoError(t, err)
 
@@ -75,6 +69,9 @@ func TestPullRequestService_Post(t *testing.T) {
 		Body:     "body",
 		Assignee: "assignee",
 	}
+	wantReqBody, _ := json.Marshal(params)
+	stubPost(t, "/repos/octokit/go-octokit/pulls", "pull_request", nil, string(wantReqBody)+"\n", nil)
+
 	pr, result := client.PullRequests(url).Create(params)
 
 	assert.False(t, result.HasError())

--- a/octokit/releases_test.go
+++ b/octokit/releases_test.go
@@ -1,7 +1,7 @@
 package octokit
 
 import (
-	"net/http"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,12 +55,6 @@ func TestCreateRelease(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/octokit/Hello-World/releases", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
-		testBody(t, r, "{\"tag_name\":\"v1.0.0\",\"target_commitish\":\"master\"}\n")
-		respondWithJSON(w, loadFixture("create_release.json"))
-	})
-
 	url, err := ReleasesURL.Expand(M{"owner": "octokit", "repo": "Hello-World"})
 	assert.NoError(t, err)
 
@@ -68,6 +62,9 @@ func TestCreateRelease(t *testing.T) {
 		TagName:         "v1.0.0",
 		TargetCommitish: "master",
 	}
+	wantReqBody, _ := json.Marshal(params)
+	stubPost(t, "/repos/octokit/Hello-World/releases", "create_release", nil, string(wantReqBody)+"\n", nil)
+
 	release, result := client.Releases(url).Create(params)
 
 	assert.False(t, result.HasError())
@@ -78,12 +75,6 @@ func TestUpdateRelease(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/repos/octokit/Hello-World/releases/123", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PATCH")
-		testBody(t, r, "{\"tag_name\":\"v1.0.0\",\"target_commitish\":\"master\"}\n")
-		respondWithJSON(w, loadFixture("create_release.json"))
-	})
-
 	url, err := ReleasesURL.Expand(M{"owner": "octokit", "repo": "Hello-World", "id": "123"})
 	assert.NoError(t, err)
 
@@ -91,6 +82,9 @@ func TestUpdateRelease(t *testing.T) {
 		TagName:         "v1.0.0",
 		TargetCommitish: "master",
 	}
+	wantReqBody, _ := json.Marshal(params)
+	stubPatch(t, "/repos/octokit/Hello-World/releases/123", "create_release", nil, string(wantReqBody)+"\n", nil)
+
 	release, result := client.Releases(url).Update(params)
 
 	assert.False(t, result.HasError())

--- a/octokit/repo_collaborators_test.go
+++ b/octokit/repo_collaborators_test.go
@@ -26,8 +26,7 @@ func TestCollaboratorsService_IsCollaborator(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	stubGetWithStatusCode(t,
-		"/repos/octokit/go-octokit/collaborators/dhruvsinghal", 204)
+	stubGetwCode(t, "/repos/octokit/go-octokit/collaborators/dhruvsinghal", "", nil, 204)
 
 	isCollaborator, result := client.Collaborators().IsCollaborator(nil,
 		M{"owner": "octokit", "repo": "go-octokit",

--- a/octokit/users_test.go
+++ b/octokit/users_test.go
@@ -1,6 +1,7 @@
 package octokit
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -34,14 +35,11 @@ func TestUsersService_UpdateCurrentUser(t *testing.T) {
 	setup()
 	defer tearDown()
 
-	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		testBody(t, r, "{\"email\":\"jingweno@gmail.com\"}\n")
-		respondWithJSON(w, loadFixture("user.json"))
-	})
-
 	url, _ := CurrentUserURL.Expand(nil)
 	userToUpdate := User{Email: "jingweno@gmail.com"}
+	wantReqBody, _ := json.Marshal(userToUpdate)
+	stubPutwCode(t, "/user", "user", nil, string(wantReqBody)+"\n", nil, 0)
+
 	user, result := client.Users(url).Update(userToUpdate)
 
 	assert.False(t, result.HasError())


### PR DESCRIPTION
The update respected the original implementations. For example, some of the tests never used fixtures, some of them tested on unique aspects of the request. These tests are left with inline `mux.HandleFunc` implementations.

Please review.