### PR TITLE
Service for get the combined status for a specific ref

### DIFF
--- a/octokit/status.go
+++ b/octokit/status.go
@@ -1,0 +1,33 @@
+package octokit
+
+import (
+	"net/url"
+
+	"github.com/jingweno/go-sawyer/hypermedia"
+)
+
+// https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
+var StatusURL = Hyperlink("repos/{owner}/{repo}/status/{ref}")
+
+func (c *Client) Status(url *url.URL) (statuses *StatusService) {
+	statuses = &StatusService{client: c, URL: url}
+	return
+}
+
+type StatusService struct {
+	client *Client
+	URL    *url.URL
+}
+
+func (s *StatusService) Get() (status *StatusCombined, result *Result) {
+	result = s.client.get(s.URL, &status)
+	return
+}
+
+type StatusCombined struct {
+	*hypermedia.HALResource
+
+	State      string `json:"state,omitempty"`
+	TotalCount int    `json:"total_count,omitempty"`
+	Sha        string `json:"sha,omitempty"`
+}

--- a/octokit/status_test.go
+++ b/octokit/status_test.go
@@ -1,0 +1,25 @@
+package octokit
+
+import (
+	"testing"
+
+	"net/url"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusUrl(t *testing.T) {
+	sha := "740211b9c6cd8e526a7124fe2b33115602fbc637"
+	url, err := StatusURL.Expand(M{"owner": "jingweno", "repo": "gh", "ref": sha})
+	assert.NoError(t, err)
+	assert.Equal(t, "repos/jingweno/gh/status/740211b9c6cd8e526a7124fe2b33115602fbc637", url.String())
+}
+
+func TestStatus(t *testing.T) {
+	url := &url.URL{}
+	c := &Client{}
+	service := c.Status(url)
+	assert.NotNil(t, service)
+	assert.Equal(t, service.client, c)
+	assert.Equal(t, service.URL, url)
+}


### PR DESCRIPTION
Hi,
I added a service for the combined status of a ref:
https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
