### PR TITLE
Add `Labels` to `PullRequest`

### DIFF
--- a/octokit/pull_requests.go
+++ b/octokit/pull_requests.go
@@ -114,6 +114,7 @@ type PullRequest struct {
 	ChangedFiles      int               `json:"changed_files,omitempty"`
 	Mergeable         *bool             `json:"mergeable,omitempty"`
 	MergeableState    string            `json:"mergeable_state,omitempty"`
+	Labels            []Label           `json:"labels,omitempty"`
 }
 
 // PullRequestCommit represents one of the commits associated with the given


### PR DESCRIPTION
Since the GitHub API now returns a `Labels` JSON array, adding it to the `PullRequest` struct. Should this be added to the test as well?